### PR TITLE
Support cache_read.active_support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,4 +18,9 @@ Metrics/ClassLength:
 Minitest/AssertEmptyLiteral:
   Enabled: false
 
+# `assert_equal(false, object)` and `assert_equal(nil, object)` are different when it comes to their types,
+# so this cop does not make sense to me.
+Minitest/RefuteFalse:
+  Enabled: false
+
 # If you feel annoyed by the current configuration, let's tweak the configuration!

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ rails_band does not limit you only to use logging purposes. Enjoy with Rails Ins
 
 ### Active Support
 
-* [ ] [`cache_read.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-read-active-support)
+* [x] [`cache_read.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-read-active-support)
 * [ ] [`cache_generate.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-generate-active-support)
 * [ ] [`cache_fetch_hit.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-fetch-hit-active-support)
 * [ ] [`cache_write.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-write-active-support)

--- a/lib/rails_band.rb
+++ b/lib/rails_band.rb
@@ -23,4 +23,8 @@ module RailsBand
   module ActionMailer
     autoload :LogSubscriber, 'rails_band/action_mailer/log_subscriber'
   end
+
+  module ActiveSupport
+    autoload :LogSubscriber, 'rails_band/active_support/log_subscriber'
+  end
 end

--- a/lib/rails_band/active_support/event/cache_read.rb
+++ b/lib/rails_band/active_support/event/cache_read.rb
@@ -9,8 +9,10 @@ module RailsBand
           @key ||= @event.payload.fetch(:key)
         end
 
-        def store
-          @store ||= @event.payload.fetch(:store)
+        if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1')
+          define_method(:store) do
+            @store ||= @event.payload.fetch(:store)
+          end
         end
 
         def hit

--- a/lib/rails_band/active_support/event/cache_read.rb
+++ b/lib/rails_band/active_support/event/cache_read.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActiveSupport
+    module Event
+      # A wrapper for the event that is passed to `cache_read.active_support`.
+      class CacheRead < BaseEvent
+        def key
+          @key ||= @event.payload.fetch(:key)
+        end
+
+        def store
+          @store ||= @event.payload.fetch(:store)
+        end
+
+        def hit
+          return @hit if defined? @hit
+
+          @hit = @event.payload[:hit]
+        end
+
+        def super_operation
+          return @super_operation if defined? @super_operation
+
+          @super_operation = @event.payload[:super_operation]
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/active_support/log_subscriber.rb
+++ b/lib/rails_band/active_support/log_subscriber.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_band/active_support/event/cache_read'
+
+module RailsBand
+  module ActiveSupport
+    # The custom LogSubscriber for ActiveSupport.
+    class LogSubscriber < ::ActiveSupport::LogSubscriber
+      mattr_accessor :consumers
+
+      def cache_read(event)
+        consumer_of(__method__)&.call(Event::CacheRead.new(event))
+      end
+
+      private
+
+      def consumer_of(sub_event)
+        consumers[:"#{sub_event}.active_support"] || consumers[:active_support] || consumers[:default]
+      end
+    end
+  end
+end

--- a/lib/rails_band/railtie.rb
+++ b/lib/rails_band/railtie.rb
@@ -29,6 +29,8 @@ module RailsBand
         require 'action_mailer/log_subscriber'
         swap.call(::ActionMailer::LogSubscriber, RailsBand::ActionMailer::LogSubscriber, :action_mailer)
       end
+
+      RailsBand::ActiveSupport::LogSubscriber.attach_to :active_support
     end
   end
 end

--- a/test/dummy/app/controllers/users_controller.rb
+++ b/test/dummy/app/controllers/users_controller.rb
@@ -68,6 +68,15 @@ class UsersController < ApplicationController
     redirect_to users_path
   end
 
+  def cache
+    user = User.find(params.require(:user_id))
+    result = Rails.cache.fetch(user.id, expires_in: 1.minutes) do
+      user.slow_method
+    end
+    logger.info(result)
+    redirect_to user_path(user)
+  end
+
   private
 
   def halt!

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -4,4 +4,8 @@ class User < ApplicationRecord
   has_many :notes, dependent: :destroy
   validates :email, presence: true
   validates :name, presence: true
+
+  def slow_method
+    "Slow! for #{id}"
+  end
 end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -9,5 +9,6 @@ Rails.application.routes.draw do
     get :callback
     get :notes
     get :welcome_email
+    get :cache
   end
 end

--- a/test/rails_band/active_support/event/cache_read_test.rb
+++ b/test/rails_band/active_support/event/cache_read_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CacheReadTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = nil
+    RailsBand::ActiveSupport::LogSubscriber.consumers = {
+      'cache_read.active_support': ->(event) { @event = event }
+    }
+    @user = User.create!(name: 'foo', email: 'foo@example.com')
+  end
+
+  test 'returns name' do
+    get "/users/#{@user.id}/cache"
+    assert_equal 'cache_read.active_support', @event.name
+  end
+
+  test 'returns time' do
+    get "/users/#{@user.id}/cache"
+    assert_instance_of Float, @event.time
+  end
+
+  test 'returns end' do
+    get "/users/#{@user.id}/cache"
+    assert_instance_of Float, @event.end
+  end
+
+  test 'returns transaction_id' do
+    get "/users/#{@user.id}/cache"
+    assert_instance_of String, @event.transaction_id
+  end
+
+  test 'returns children' do
+    get "/users/#{@user.id}/cache"
+    assert_instance_of Array, @event.children
+  end
+
+  test 'returns cpu_time' do
+    get "/users/#{@user.id}/cache"
+    assert_instance_of Float, @event.cpu_time
+  end
+
+  test 'returns idle_time' do
+    get "/users/#{@user.id}/cache"
+    assert_instance_of Float, @event.idle_time
+  end
+
+  test 'returns allocations' do
+    get "/users/#{@user.id}/cache"
+    assert_instance_of Integer, @event.allocations
+  end
+
+  test 'returns duration' do
+    get "/users/#{@user.id}/cache"
+    assert_instance_of Float, @event.duration
+  end
+
+  test 'calls #to_h' do
+    get "/users/#{@user.id}/cache"
+    %i[name time end transaction_id children cpu_time idle_time allocations duration key store hit
+       super_operation].each do |key|
+      assert_includes @event.to_h, key
+    end
+  end
+
+  test 'calls #slice' do
+    get "/users/#{@user.id}/cache"
+    assert_equal({ name: 'cache_read.active_support' }, @event.slice(:name))
+  end
+
+  test 'returns an instance of CacheRead' do
+    get "/users/#{@user.id}/cache"
+    assert_instance_of RailsBand::ActiveSupport::Event::CacheRead, @event
+  end
+
+  test 'returns key' do
+    get "/users/#{@user.id}/cache"
+    assert_equal @user.id, @event.key
+  end
+
+  test 'returns store' do
+    get "/users/#{@user.id}/cache"
+    assert_equal 'ActiveSupport::Cache::NullStore', @event.store
+  end
+
+  test 'returns hit' do
+    get "/users/#{@user.id}/cache"
+    assert_equal false, @event.hit
+  end
+
+  test 'returns super_operation' do
+    get "/users/#{@user.id}/cache"
+    assert_equal :fetch, @event.super_operation
+  end
+end

--- a/test/rails_band/active_support/event/cache_read_test.rb
+++ b/test/rails_band/active_support/event/cache_read_test.rb
@@ -58,7 +58,7 @@ class CacheReadTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get "/users/#{@user.id}/cache"
-    %i[name time end transaction_id children cpu_time idle_time allocations duration key store hit
+    %i[name time end transaction_id children cpu_time idle_time allocations duration key hit
        super_operation].each do |key|
       assert_includes @event.to_h, key
     end
@@ -79,9 +79,19 @@ class CacheReadTest < ActionDispatch::IntegrationTest
     assert_equal @user.id, @event.key
   end
 
-  test 'returns store' do
-    get "/users/#{@user.id}/cache"
-    assert_equal 'ActiveSupport::Cache::NullStore', @event.store
+  if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1')
+    test 'returns store' do
+      get "/users/#{@user.id}/cache"
+      assert_equal 'ActiveSupport::Cache::NullStore', @event.store
+    end
+  else
+    test 'raises NoMethodError when accessing store' do
+      get "/users/#{@user.id}/cache"
+      get '/users'
+      assert_raises NoMethodError do
+        @event.store
+      end
+    end
   end
 
   test 'returns hit' do

--- a/test/rails_band/active_support/log_subscriber_test.rb
+++ b/test/rails_band/active_support/log_subscriber_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ActiveSupportLogSubscriberTest < ActionDispatch::IntegrationTest
+  setup do
+    @mock = Minitest::Mock.new
+    @mock.expect(:recv, nil)
+    @user = User.create!(name: 'mc', email: 'mc@example.com')
+  end
+
+  test 'use the consumer with the exact event name' do
+    RailsBand::ActiveSupport::LogSubscriber.consumers = {
+      'cache_read.active_support': ->(_event) { @mock.recv }
+    }
+    get "/users/#{@user.id}/cache"
+    assert_mock @mock
+  end
+
+  test 'use the consumer with namespace' do
+    RailsBand::ActiveSupport::LogSubscriber.consumers = {
+      active_support: ->(event) { @mock.recv if event.name == 'cache_read.active_support' }
+    }
+    get "/users/#{@user.id}/cache"
+    assert_mock @mock
+  end
+
+  test 'use the consumer with default' do
+    RailsBand::ActiveSupport::LogSubscriber.consumers = {
+      default: ->(event) { @mock.recv if event.name == 'cache_read.active_support' }
+    }
+    get "/users/#{@user.id}/cache"
+    assert_mock @mock
+  end
+
+  test 'do not use the consumer because the event is not for the target' do
+    RailsBand::ActiveSupport::LogSubscriber.consumers = {
+      'unknown.active_support': ->(_event) { @mock.recv }
+    }
+    get "/users/#{@user.id}/cache"
+    assert_raises MockExpectationError do
+      @mock.verify
+    end
+  end
+end

--- a/test/rails_band/configuration_test.rb
+++ b/test/rails_band/configuration_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 module RailsBand
-  class ConfigurationTest < ActiveSupport::TestCase
+  class ConfigurationTest < ::ActiveSupport::TestCase
     test 'it can accept the consumers with a block' do
       config = RailsBand::Configuration.new
       config.consumers = ->(v) { v + 1 }


### PR DESCRIPTION
Support [`cache_read.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-read-active-support).