### PR TITLE
Support cache_generate.active_support

### DIFF
--- a/lib/rails_band/active_support/event/cache_generate.rb
+++ b/lib/rails_band/active_support/event/cache_generate.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActiveSupport
+    module Event
+      # A wrapper for the event that is passed to `cache_generate.active_support`.
+      class CacheGenerate < BaseEvent
+        def key
+          @key ||= @event.payload.fetch(:key)
+        end
+
+        if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1')
+          define_method(:store) do
+            @store ||= @event.payload.fetch(:store)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/active_support/log_subscriber.rb
+++ b/lib/rails_band/active_support/log_subscriber.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_band/active_support/event/cache_read'
+require 'rails_band/active_support/event/cache_generate'
 
 module RailsBand
   module ActiveSupport
@@ -10,6 +11,10 @@ module RailsBand
 
       def cache_read(event)
         consumer_of(__method__)&.call(Event::CacheRead.new(event))
+      end
+
+      def cache_generate(event)
+        consumer_of(__method__)&.call(Event::CacheGenerate.new(event))
       end
 
       private

--- a/test/rails_band/active_support/event/cache_generate_test.rb
+++ b/test/rails_band/active_support/event/cache_generate_test.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CacheGenerateTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = nil
+    RailsBand::ActiveSupport::LogSubscriber.consumers = {
+      'cache_generate.active_support': ->(event) { @event = event }
+    }
+    @user = User.create!(name: 'foo', email: 'foo@example.com')
+  end
+
+  test 'returns name' do
+    get "/users/#{@user.id}/cache"
+    assert_equal 'cache_generate.active_support', @event.name
+  end
+
+  test 'returns time' do
+    get "/users/#{@user.id}/cache"
+    assert_instance_of Float, @event.time
+  end
+
+  test 'returns end' do
+    get "/users/#{@user.id}/cache"
+    assert_instance_of Float, @event.end
+  end
+
+  test 'returns transaction_id' do
+    get "/users/#{@user.id}/cache"
+    assert_instance_of String, @event.transaction_id
+  end
+
+  test 'returns children' do
+    get "/users/#{@user.id}/cache"
+    assert_instance_of Array, @event.children
+  end
+
+  test 'returns cpu_time' do
+    get "/users/#{@user.id}/cache"
+    assert_instance_of Float, @event.cpu_time
+  end
+
+  test 'returns idle_time' do
+    get "/users/#{@user.id}/cache"
+    assert_instance_of Float, @event.idle_time
+  end
+
+  test 'returns allocations' do
+    get "/users/#{@user.id}/cache"
+    assert_instance_of Integer, @event.allocations
+  end
+
+  test 'returns duration' do
+    get "/users/#{@user.id}/cache"
+    assert_instance_of Float, @event.duration
+  end
+
+  test 'calls #to_h' do
+    get "/users/#{@user.id}/cache"
+    %i[name time end transaction_id children cpu_time idle_time allocations duration key].each do |key|
+      assert_includes @event.to_h, key
+    end
+  end
+
+  test 'calls #slice' do
+    get "/users/#{@user.id}/cache"
+    assert_equal({ name: 'cache_generate.active_support' }, @event.slice(:name))
+  end
+
+  test 'returns an instance of CacheGenerate' do
+    get "/users/#{@user.id}/cache"
+    assert_instance_of RailsBand::ActiveSupport::Event::CacheGenerate, @event
+  end
+
+  test 'returns key' do
+    get "/users/#{@user.id}/cache"
+    assert_equal @user.id, @event.key
+  end
+
+  if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1')
+    test 'returns store' do
+      get "/users/#{@user.id}/cache"
+      assert_equal 'ActiveSupport::Cache::NullStore', @event.store
+    end
+  else
+    test 'raises NoMethodError when accessing store' do
+      get "/users/#{@user.id}/cache"
+      get '/users'
+      assert_raises NoMethodError do
+        @event.store
+      end
+    end
+  end
+end


### PR DESCRIPTION
Support [`cache_generate.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-generate-active-support).