### PR TITLE
Support cache_fetch_hit.active_support

### DIFF
--- a/lib/rails_band/active_support/event/cache_fetch_hit.rb
+++ b/lib/rails_band/active_support/event/cache_fetch_hit.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActiveSupport
+    module Event
+      # A wrapper for the event that is passed to `cache_fetch_hit.active_support`.
+      class CacheFetchHit < BaseEvent
+        def key
+          @key ||= @event.payload.fetch(:key)
+        end
+
+        if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1')
+          define_method(:store) do
+            @store ||= @event.payload.fetch(:store)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/active_support/log_subscriber.rb
+++ b/lib/rails_band/active_support/log_subscriber.rb
@@ -2,6 +2,7 @@
 
 require 'rails_band/active_support/event/cache_read'
 require 'rails_band/active_support/event/cache_generate'
+require 'rails_band/active_support/event/cache_fetch_hit'
 
 module RailsBand
   module ActiveSupport
@@ -15,6 +16,10 @@ module RailsBand
 
       def cache_generate(event)
         consumer_of(__method__)&.call(Event::CacheGenerate.new(event))
+      end
+
+      def cache_fetch_hit(event)
+        consumer_of(__method__)&.call(Event::CacheFetchHit.new(event))
       end
 
       private

--- a/test/dummy/app/controllers/users_controller.rb
+++ b/test/dummy/app/controllers/users_controller.rb
@@ -77,6 +77,13 @@ class UsersController < ApplicationController
     redirect_to user_path(user)
   end
 
+  def cache2
+    Rails.cache.fetch('ok', expires_in: 1.minutes) { 'ok' }
+    result = Rails.cache.fetch('ok', expires_in: 1.minutes) { 'ok' }
+    logger.info(result)
+    redirect_to users_path
+  end
+
   private
 
   def halt!

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -10,5 +10,6 @@ Rails.application.routes.draw do
     get :notes
     get :welcome_email
     get :cache
+    get :cache2
   end
 end

--- a/test/rails_band/active_support/event/cache_fetch_hit_test.rb
+++ b/test/rails_band/active_support/event/cache_fetch_hit_test.rb
@@ -2,90 +2,89 @@
 
 require 'test_helper'
 
-class CacheGenerateTest < ActionDispatch::IntegrationTest
+class CacheFetchHitTest < ActionDispatch::IntegrationTest
   setup do
     @event = nil
     RailsBand::ActiveSupport::LogSubscriber.consumers = {
-      'cache_generate.active_support': ->(event) { @event = event }
+      'cache_fetch_hit.active_support': ->(event) { @event = event }
     }
-    @user = User.create!(name: 'foo', email: 'foo@example.com')
   end
 
   test 'returns name' do
-    get "/users/#{@user.id}/cache"
-    assert_equal 'cache_generate.active_support', @event.name
+    get '/users/123/cache2'
+    assert_equal 'cache_fetch_hit.active_support', @event.name
   end
 
   test 'returns time' do
-    get "/users/#{@user.id}/cache"
+    get '/users/123/cache2'
     assert_instance_of Float, @event.time
   end
 
   test 'returns end' do
-    get "/users/#{@user.id}/cache"
+    get '/users/123/cache2'
     assert_instance_of Float, @event.end
   end
 
   test 'returns transaction_id' do
-    get "/users/#{@user.id}/cache"
+    get '/users/123/cache2'
     assert_instance_of String, @event.transaction_id
   end
 
   test 'returns children' do
-    get "/users/#{@user.id}/cache"
+    get '/users/123/cache2'
     assert_instance_of Array, @event.children
   end
 
   test 'returns cpu_time' do
-    get "/users/#{@user.id}/cache"
+    get '/users/123/cache2'
     assert_instance_of Float, @event.cpu_time
   end
 
   test 'returns idle_time' do
-    get "/users/#{@user.id}/cache"
+    get '/users/123/cache2'
     assert_instance_of Float, @event.idle_time
   end
 
   test 'returns allocations' do
-    get "/users/#{@user.id}/cache"
+    get '/users/123/cache2'
     assert_instance_of Integer, @event.allocations
   end
 
   test 'returns duration' do
-    get "/users/#{@user.id}/cache"
+    get '/users/123/cache2'
     assert_instance_of Float, @event.duration
   end
 
   test 'calls #to_h' do
-    get "/users/#{@user.id}/cache"
+    get '/users/123/cache2'
     %i[name time end transaction_id children cpu_time idle_time allocations duration key].each do |key|
       assert_includes @event.to_h, key
     end
   end
 
   test 'calls #slice' do
-    get "/users/#{@user.id}/cache"
-    assert_equal({ name: 'cache_generate.active_support' }, @event.slice(:name))
+    get '/users/123/cache2'
+    assert_equal({ name: 'cache_fetch_hit.active_support' }, @event.slice(:name))
   end
 
-  test 'returns an instance of CacheGenerate' do
-    get "/users/#{@user.id}/cache"
-    assert_instance_of RailsBand::ActiveSupport::Event::CacheGenerate, @event
+  test 'returns an instance of CacheFetchHit' do
+    get '/users/123/cache2'
+    assert_instance_of RailsBand::ActiveSupport::Event::CacheFetchHit, @event
   end
 
   test 'returns key' do
-    get "/users/#{@user.id}/cache"
-    assert_equal @user.id, @event.key
+    get '/users/123/cache2'
+    assert_equal 'ok', @event.key
   end
 
   if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1')
     test 'returns store' do
-      get "/users/#{@user.id}/cache"
+      get '/users/123/cache2'
       assert_equal 'ActiveSupport::Cache::NullStore', @event.store
     end
   else
     test 'raises NoMethodError when accessing store' do
-      get "/users/#{@user.id}/cache"
+      get '/users/123/cache2'
       assert_raises NoMethodError do
         @event.store
       end

--- a/test/rails_band/active_support/event/cache_read_test.rb
+++ b/test/rails_band/active_support/event/cache_read_test.rb
@@ -87,7 +87,6 @@ class CacheReadTest < ActionDispatch::IntegrationTest
   else
     test 'raises NoMethodError when accessing store' do
       get "/users/#{@user.id}/cache"
-      get '/users'
       assert_raises NoMethodError do
         @event.store
       end


### PR DESCRIPTION
Support [`cache_fetch_hit.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-fetch-hit-active-support).