### PR TITLE
Support cache_delete.active_support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ rails_band does not limit you only to use logging purposes. Enjoy with Rails Ins
 * [x] [`cache_fetch_hit.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-fetch-hit-active-support)
 * [x] [`cache_write.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-write-active-support)
 * [ ] `cache_write_multi.active_support` (Not yet documented)
-* [ ] [`cache_delete.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-delete-active-support)
+* [x] [`cache_delete.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-delete-active-support)
 * [ ] `cache_delete_multi.active_support` (Not yet documented)
 * [ ] [`cache_exist?.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-exist-questionmark-active-support)
 

--- a/lib/rails_band/active_support/event/cache_delete.rb
+++ b/lib/rails_band/active_support/event/cache_delete.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActiveSupport
+    module Event
+      # A wrapper for the event that is passed to `cache_delete.active_support`.
+      class CacheDelete < BaseEvent
+        def key
+          @key ||= @event.payload.fetch(:key)
+        end
+
+        if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1')
+          define_method(:store) do
+            @store ||= @event.payload.fetch(:store)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/active_support/log_subscriber.rb
+++ b/lib/rails_band/active_support/log_subscriber.rb
@@ -4,6 +4,7 @@ require 'rails_band/active_support/event/cache_read'
 require 'rails_band/active_support/event/cache_generate'
 require 'rails_band/active_support/event/cache_fetch_hit'
 require 'rails_band/active_support/event/cache_write'
+require 'rails_band/active_support/event/cache_delete'
 
 module RailsBand
   module ActiveSupport
@@ -25,6 +26,10 @@ module RailsBand
 
       def cache_write(event)
         consumer_of(__method__)&.call(Event::CacheWrite.new(event))
+      end
+
+      def cache_delete(event)
+        consumer_of(__method__)&.call(Event::CacheDelete.new(event))
       end
 
       private

--- a/test/dummy/app/controllers/users_controller.rb
+++ b/test/dummy/app/controllers/users_controller.rb
@@ -80,6 +80,7 @@ class UsersController < ApplicationController
   def cache2
     Rails.cache.fetch('ok', expires_in: 1.minutes) { 'ok' }
     result = Rails.cache.fetch('ok', expires_in: 1.minutes) { 'ok' }
+    Rails.cache.delete('DEL!')
     logger.info(result)
     redirect_to users_path
   end

--- a/test/rails_band/active_support/event/cache_delete_test.rb
+++ b/test/rails_band/active_support/event/cache_delete_test.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CacheDeleteTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = nil
+    RailsBand::ActiveSupport::LogSubscriber.consumers = {
+      'cache_delete.active_support': ->(event) { @event = event }
+    }
+  end
+
+  test 'returns name' do
+    get '/users/123/cache2'
+    assert_equal 'cache_delete.active_support', @event.name
+  end
+
+  test 'returns time' do
+    get '/users/123/cache2'
+    assert_instance_of Float, @event.time
+  end
+
+  test 'returns end' do
+    get '/users/123/cache2'
+    assert_instance_of Float, @event.end
+  end
+
+  test 'returns transaction_id' do
+    get '/users/123/cache2'
+    assert_instance_of String, @event.transaction_id
+  end
+
+  test 'returns children' do
+    get '/users/123/cache2'
+    assert_instance_of Array, @event.children
+  end
+
+  test 'returns cpu_time' do
+    get '/users/123/cache2'
+    assert_instance_of Float, @event.cpu_time
+  end
+
+  test 'returns idle_time' do
+    get '/users/123/cache2'
+    assert_instance_of Float, @event.idle_time
+  end
+
+  test 'returns allocations' do
+    get '/users/123/cache2'
+    assert_instance_of Integer, @event.allocations
+  end
+
+  test 'returns duration' do
+    get '/users/123/cache2'
+    assert_instance_of Float, @event.duration
+  end
+
+  test 'calls #to_h' do
+    get '/users/123/cache2'
+    %i[name time end transaction_id children cpu_time idle_time allocations duration key].each do |key|
+      assert_includes @event.to_h, key
+    end
+  end
+
+  test 'calls #slice' do
+    get '/users/123/cache2'
+    assert_equal({ name: 'cache_delete.active_support' }, @event.slice(:name))
+  end
+
+  test 'returns an instance of CacheDelete' do
+    get '/users/123/cache2'
+    assert_instance_of RailsBand::ActiveSupport::Event::CacheDelete, @event
+  end
+
+  test 'returns key' do
+    get '/users/123/cache2'
+    assert_equal 'DEL!', @event.key
+  end
+
+  if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1')
+    test 'returns store' do
+      get '/users/123/cache2'
+      assert_equal 'ActiveSupport::Cache::NullStore', @event.store
+    end
+  else
+    test 'raises NoMethodError when accessing store' do
+      get '/users/123/cache2'
+      assert_raises NoMethodError do
+        @event.store
+      end
+    end
+  end
+end


### PR DESCRIPTION
Support [`cache_delete.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-delete-active-support).