### PR TITLE
Support cache_exist?.active_support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ rails_band does not limit you only to use logging purposes. Enjoy with Rails Ins
 * [ ] `cache_write_multi.active_support` (Not yet documented)
 * [x] [`cache_delete.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-delete-active-support)
 * [ ] `cache_delete_multi.active_support` (Not yet documented)
-* [ ] [`cache_exist?.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-exist-questionmark-active-support)
+* [x] [`cache_exist?.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-exist-questionmark-active-support)
 
 ### Active Job
 

--- a/lib/rails_band/active_support/event/cache_exist.rb
+++ b/lib/rails_band/active_support/event/cache_exist.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActiveSupport
+    module Event
+      # A wrapper for the event that is passed to `cache_exist?.active_support`.
+      class CacheExist < BaseEvent
+        def key
+          @key ||= @event.payload.fetch(:key)
+        end
+
+        if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1')
+          define_method(:store) do
+            @store ||= @event.payload.fetch(:store)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/active_support/log_subscriber.rb
+++ b/lib/rails_band/active_support/log_subscriber.rb
@@ -5,6 +5,7 @@ require 'rails_band/active_support/event/cache_generate'
 require 'rails_band/active_support/event/cache_fetch_hit'
 require 'rails_band/active_support/event/cache_write'
 require 'rails_band/active_support/event/cache_delete'
+require 'rails_band/active_support/event/cache_exist'
 
 module RailsBand
   module ActiveSupport
@@ -30,6 +31,10 @@ module RailsBand
 
       def cache_delete(event)
         consumer_of(__method__)&.call(Event::CacheDelete.new(event))
+      end
+
+      def cache_exist?(event)
+        consumer_of(__method__)&.call(Event::CacheExist.new(event))
       end
 
       private

--- a/test/dummy/app/controllers/users_controller.rb
+++ b/test/dummy/app/controllers/users_controller.rb
@@ -81,6 +81,7 @@ class UsersController < ApplicationController
     Rails.cache.fetch('ok', expires_in: 1.minutes) { 'ok' }
     result = Rails.cache.fetch('ok', expires_in: 1.minutes) { 'ok' }
     Rails.cache.delete('DEL!')
+    Rails.cache.exist?('nonexistent')
     logger.info(result)
     redirect_to users_path
   end

--- a/test/rails_band/active_support/event/cache_exist_test.rb
+++ b/test/rails_band/active_support/event/cache_exist_test.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CacheExistTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = nil
+    RailsBand::ActiveSupport::LogSubscriber.consumers = {
+      'cache_exist?.active_support': ->(event) { @event = event }
+    }
+  end
+
+  test 'returns name' do
+    get '/users/123/cache2'
+    assert_equal 'cache_exist?.active_support', @event.name
+  end
+
+  test 'returns time' do
+    get '/users/123/cache2'
+    assert_instance_of Float, @event.time
+  end
+
+  test 'returns end' do
+    get '/users/123/cache2'
+    assert_instance_of Float, @event.end
+  end
+
+  test 'returns transaction_id' do
+    get '/users/123/cache2'
+    assert_instance_of String, @event.transaction_id
+  end
+
+  test 'returns children' do
+    get '/users/123/cache2'
+    assert_instance_of Array, @event.children
+  end
+
+  test 'returns cpu_time' do
+    get '/users/123/cache2'
+    assert_instance_of Float, @event.cpu_time
+  end
+
+  test 'returns idle_time' do
+    get '/users/123/cache2'
+    assert_instance_of Float, @event.idle_time
+  end
+
+  test 'returns allocations' do
+    get '/users/123/cache2'
+    assert_instance_of Integer, @event.allocations
+  end
+
+  test 'returns duration' do
+    get '/users/123/cache2'
+    assert_instance_of Float, @event.duration
+  end
+
+  test 'calls #to_h' do
+    get '/users/123/cache2'
+    %i[name time end transaction_id children cpu_time idle_time allocations duration key].each do |key|
+      assert_includes @event.to_h, key
+    end
+  end
+
+  test 'calls #slice' do
+    get '/users/123/cache2'
+    assert_equal({ name: 'cache_exist?.active_support' }, @event.slice(:name))
+  end
+
+  test 'returns an instance of CacheExist' do
+    get '/users/123/cache2'
+    assert_instance_of RailsBand::ActiveSupport::Event::CacheExist, @event
+  end
+
+  test 'returns key' do
+    get '/users/123/cache2'
+    assert_equal 'nonexistent', @event.key
+  end
+
+  if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1')
+    test 'returns store' do
+      get '/users/123/cache2'
+      assert_equal 'ActiveSupport::Cache::NullStore', @event.store
+    end
+  else
+    test 'raises NoMethodError when accessing store' do
+      get '/users/123/cache2'
+      assert_raises NoMethodError do
+        @event.store
+      end
+    end
+  end
+end


### PR DESCRIPTION
Support [`cache_exist?.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-exist-questionmark-active-support).