### PR TITLE
Support enqueue_at.active_job

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,4 +23,8 @@ Minitest/AssertEmptyLiteral:
 Minitest/RefuteFalse:
   Enabled: false
 
+# `after_initialize` requires many block length.
+Metrics/BlockLength:
+  Max: 50
+
 # If you feel annoyed by the current configuration, let's tweak the configuration!

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 
 | Event name                                                                                                                | Supported |
 | ------------------------------------------------------------------------------------------------------------------------- | --------- |
-| [`enqueue_at.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#enqueue-at-active-job)       |           |
+| [`enqueue_at.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#enqueue-at-active-job)       | ✅        |
 | [`enqueue.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#enqueue-active-job)             |           |
 | [`enqueue_retry.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#enqueue-retry-active-job) |           |
 | [`perform_start.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#perform-start-active-job) |           |

--- a/lib/rails_band.rb
+++ b/lib/rails_band.rb
@@ -27,4 +27,8 @@ module RailsBand
   module ActiveSupport
     autoload :LogSubscriber, 'rails_band/active_support/log_subscriber'
   end
+
+  module ActiveJob
+    autoload :LogSubscriber, 'rails_band/active_job/log_subscriber'
+  end
 end

--- a/lib/rails_band/active_job/event/enqueue_at.rb
+++ b/lib/rails_band/active_job/event/enqueue_at.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActiveJob
+    module Event
+      # A wrapper for the event that is passed to `enqueue_at.active_job`.
+      class EnqueueAt < BaseEvent
+        def adapter
+          @adapter ||= @event.payload.fetch(:adapter)
+        end
+
+        def job
+          @job ||= @event.payload.fetch(:job)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/active_job/log_subscriber.rb
+++ b/lib/rails_band/active_job/log_subscriber.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_band/active_job/event/enqueue_at'
+
+module RailsBand
+  module ActiveJob
+    # The custom LogSubscriber for ActiveJob.
+    class LogSubscriber < ::ActiveSupport::LogSubscriber
+      mattr_accessor :consumers
+
+      def enqueue_at(event)
+        consumer_of(__method__)&.call(Event::EnqueueAt.new(event))
+      end
+
+      private
+
+      def consumer_of(sub_event)
+        consumers[:"#{sub_event}.active_job"] || consumers[:active_job] || consumers[:default]
+      end
+    end
+  end
+end

--- a/lib/rails_band/railtie.rb
+++ b/lib/rails_band/railtie.rb
@@ -31,6 +31,17 @@ module RailsBand
       end
 
       RailsBand::ActiveSupport::LogSubscriber.attach_to :active_support
+
+      if defined?(::ActiveJob)
+        require 'active_job/logging'
+
+        if defined?(::ActiveJob::Logging::LogSubscriber)
+          swap.call(::ActiveJob::Logging::LogSubscriber, RailsBand::ActiveJob::LogSubscriber, :active_job)
+        else
+          require 'active_job/log_subscriber'
+          swap.call(::ActiveJob::LogSubscriber, RailsBand::ActiveJob::LogSubscriber, :active_job)
+        end
+      end
     end
   end
 end

--- a/test/dummy/app/controllers/yay_controller.rb
+++ b/test/dummy/app/controllers/yay_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class YayController < ApplicationController
+  def index
+    YayJob.set(wait: 30.seconds).perform_later(name: 'foo', message: 'Hi')
+    head :no_content
+  end
+end

--- a/test/dummy/app/jobs/yay_job.rb
+++ b/test/dummy/app/jobs/yay_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class YayJob < ApplicationJob
+  queue_as :default
+
+  def perform(name:, message:)
+    p [name, message]
+  end
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -13,4 +13,6 @@ Rails.application.routes.draw do
     get :cache2
     get :cache3
   end
+
+  resources :yay, only: %i[index]
 end

--- a/test/rails_band/active_job/event/enqueue_at_test.rb
+++ b/test/rails_band/active_job/event/enqueue_at_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class EnqueueAtTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = nil
+    RailsBand::ActiveJob::LogSubscriber.consumers = {
+      'enqueue_at.active_job': ->(event) { @event = event }
+    }
+  end
+
+  test 'returns name' do
+    get '/yay'
+    assert_equal 'enqueue_at.active_job', @event.name
+  end
+
+  test 'returns time' do
+    get '/yay'
+    assert_instance_of Float, @event.time
+  end
+
+  test 'returns end' do
+    get '/yay'
+    assert_instance_of Float, @event.end
+  end
+
+  test 'returns transaction_id' do
+    get '/yay'
+    assert_instance_of String, @event.transaction_id
+  end
+
+  test 'returns children' do
+    get '/yay'
+    assert_instance_of Array, @event.children
+  end
+
+  test 'returns cpu_time' do
+    get '/yay'
+    assert_instance_of Float, @event.cpu_time
+  end
+
+  test 'returns idle_time' do
+    get '/yay'
+    assert_instance_of Float, @event.idle_time
+  end
+
+  test 'returns allocations' do
+    get '/yay'
+    assert_instance_of Integer, @event.allocations
+  end
+
+  test 'returns duration' do
+    get '/yay'
+    assert_instance_of Float, @event.duration
+  end
+
+  test 'calls #to_h' do
+    get '/yay'
+    %i[name time end transaction_id children cpu_time idle_time allocations duration adapter job].each do |key|
+      assert_includes @event.to_h, key
+    end
+  end
+
+  test 'calls #slice' do
+    get '/yay'
+    assert_equal({ name: 'enqueue_at.active_job' }, @event.slice(:name))
+  end
+
+  test 'returns an instance of EnqueueAt' do
+    get '/yay'
+    assert_instance_of RailsBand::ActiveJob::Event::EnqueueAt, @event
+  end
+
+  test 'returns adapter' do
+    get '/yay'
+    assert_instance_of ::ActiveJob::QueueAdapters::TestAdapter, @event.adapter
+  end
+
+  test 'returns job' do
+    get '/yay'
+    assert_instance_of YayJob, @event.job
+  end
+end

--- a/test/rails_band/active_job/log_subscriber_test.rb
+++ b/test/rails_band/active_job/log_subscriber_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ActiveJobLogSubscriberTest < ActionDispatch::IntegrationTest
+  setup do
+    @mock = Minitest::Mock.new
+    @mock.expect(:recv, nil)
+  end
+
+  test 'use the consumer with the exact event name' do
+    RailsBand::ActiveJob::LogSubscriber.consumers = {
+      'enqueue_at.active_job': ->(_event) { @mock.recv }
+    }
+    get '/yay'
+    assert_mock @mock
+  end
+
+  test 'use the consumer with namespace' do
+    RailsBand::ActiveJob::LogSubscriber.consumers = {
+      active_job: ->(event) { @mock.recv if event.name == 'enqueue_at.active_job' }
+    }
+    get '/yay'
+    assert_mock @mock
+  end
+
+  test 'use the consumer with default' do
+    RailsBand::ActiveJob::LogSubscriber.consumers = {
+      default: ->(event) { @mock.recv if event.name == 'enqueue_at.active_job' }
+    }
+    get '/yay'
+    assert_mock @mock
+  end
+
+  test 'do not use the consumer because the event is not for the target' do
+    RailsBand::ActiveJob::LogSubscriber.consumers = {
+      'unknown.active_job': ->(_event) { @mock.recv }
+    }
+    get '/yay'
+    assert_raises MockExpectationError do
+      @mock.verify
+    end
+  end
+end


### PR DESCRIPTION
Support [enqueue_at.active_job](https://guides.rubyonrails.org/active_support_instrumentation.html#enqueue-at-active-job).