### PR TITLE
Support enqueue.active_job

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 | Event name                                                                                                                | Supported |
 | ------------------------------------------------------------------------------------------------------------------------- | --------- |
 | [`enqueue_at.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#enqueue-at-active-job)       | ✅        |
-| [`enqueue.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#enqueue-active-job)             | ✅         |
+| [`enqueue.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#enqueue-active-job)             | ✅        |
 | [`enqueue_retry.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#enqueue-retry-active-job) |           |
 | [`perform_start.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#perform-start-active-job) |           |
 | [`perform.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#perform-active-job)             |           |

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 | Event name                                                                                                                | Supported |
 | ------------------------------------------------------------------------------------------------------------------------- | --------- |
 | [`enqueue_at.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#enqueue-at-active-job)       | ✅        |
-| [`enqueue.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#enqueue-active-job)             |           |
+| [`enqueue.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#enqueue-active-job)             | ✅         |
 | [`enqueue_retry.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#enqueue-retry-active-job) |           |
 | [`perform_start.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#perform-start-active-job) |           |
 | [`perform.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#perform-active-job)             |           |

--- a/lib/rails_band/active_job/event/enqueue.rb
+++ b/lib/rails_band/active_job/event/enqueue.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActiveJob
+    module Event
+      # A wrapper for the event that is passed to `enqueue.active_job`.
+      class Enqueue < BaseEvent
+        def adapter
+          @adapter ||= @event.payload.fetch(:adapter)
+        end
+
+        def job
+          @job ||= @event.payload.fetch(:job)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/active_job/log_subscriber.rb
+++ b/lib/rails_band/active_job/log_subscriber.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_band/active_job/event/enqueue_at'
+require 'rails_band/active_job/event/enqueue'
 
 module RailsBand
   module ActiveJob
@@ -10,6 +11,10 @@ module RailsBand
 
       def enqueue_at(event)
         consumer_of(__method__)&.call(Event::EnqueueAt.new(event))
+      end
+
+      def enqueue(event)
+        consumer_of(__method__)&.call(Event::Enqueue.new(event))
       end
 
       private

--- a/test/dummy/app/controllers/yay_controller.rb
+++ b/test/dummy/app/controllers/yay_controller.rb
@@ -5,4 +5,9 @@ class YayController < ApplicationController
     YayJob.set(wait: 30.seconds).perform_later(name: 'foo', message: 'Hi')
     head :no_content
   end
+
+  def show
+    YayJob.perform_later(name: 'E!', message: 'This is E.')
+    head :no_content
+  end
 end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -14,5 +14,5 @@ Rails.application.routes.draw do
     get :cache3
   end
 
-  resources :yay, only: %i[index]
+  resources :yay, only: %i[index show]
 end

--- a/test/rails_band/active_job/event/enqueue_test.rb
+++ b/test/rails_band/active_job/event/enqueue_test.rb
@@ -2,84 +2,84 @@
 
 require 'test_helper'
 
-class EnqueueAtTest < ActionDispatch::IntegrationTest
+class EnqueueTest < ActionDispatch::IntegrationTest
   setup do
     @event = nil
     RailsBand::ActiveJob::LogSubscriber.consumers = {
-      'enqueue_at.active_job': ->(event) { @event = event }
+      'enqueue.active_job': ->(event) { @event = event }
     }
   end
 
   test 'returns name' do
-    get '/yay'
-    assert_equal 'enqueue_at.active_job', @event.name
+    get '/yay/123'
+    assert_equal 'enqueue.active_job', @event.name
   end
 
   test 'returns time' do
-    get '/yay'
+    get '/yay/123'
     assert_instance_of Float, @event.time
   end
 
   test 'returns end' do
-    get '/yay'
+    get '/yay/123'
     assert_instance_of Float, @event.end
   end
 
   test 'returns transaction_id' do
-    get '/yay'
+    get '/yay/123'
     assert_instance_of String, @event.transaction_id
   end
 
   test 'returns children' do
-    get '/yay'
+    get '/yay/123'
     assert_instance_of Array, @event.children
   end
 
   test 'returns cpu_time' do
-    get '/yay'
+    get '/yay/123'
     assert_instance_of Float, @event.cpu_time
   end
 
   test 'returns idle_time' do
-    get '/yay'
+    get '/yay/123'
     assert_instance_of Float, @event.idle_time
   end
 
   test 'returns allocations' do
-    get '/yay'
+    get '/yay/123'
     assert_instance_of Integer, @event.allocations
   end
 
   test 'returns duration' do
-    get '/yay'
+    get '/yay/123'
     assert_instance_of Float, @event.duration
   end
 
   test 'calls #to_h' do
-    get '/yay'
+    get '/yay/123'
     %i[name time end transaction_id children cpu_time idle_time allocations duration adapter job].each do |key|
       assert_includes @event.to_h, key
     end
   end
 
   test 'calls #slice' do
-    get '/yay'
-    assert_equal({ name: 'enqueue_at.active_job' }, @event.slice(:name))
+    get '/yay/123'
+    assert_equal({ name: 'enqueue.active_job' }, @event.slice(:name))
   end
 
-  test 'returns an instance of EnqueueAt' do
-    get '/yay'
-    assert_instance_of RailsBand::ActiveJob::Event::EnqueueAt, @event
+  test 'returns an instance of Enqueue' do
+    get '/yay/123'
+    assert_instance_of RailsBand::ActiveJob::Event::Enqueue, @event
   end
 
   test 'returns adapter' do
-    get '/yay'
+    get '/yay/123'
     assert_instance_of ::ActiveJob::QueueAdapters::TestAdapter, @event.adapter
   end
 
   test 'returns job' do
-    get '/yay'
+    get '/yay/123'
     assert_instance_of YayJob, @event.job
-    assert_equal [{ name: 'foo', message: 'Hi' }], @event.job.arguments
+    assert_equal [{ name: 'E!', message: 'This is E.' }], @event.job.arguments
   end
 end


### PR DESCRIPTION
Support [`enqueue.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#enqueue-active-job)