### PR TITLE
Support enqueue_retry.active_job

### DIFF
--- a/lib/rails_band/active_job/event/enqueue_retry.rb
+++ b/lib/rails_band/active_job/event/enqueue_retry.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActiveJob
+    module Event
+      # A wrapper for the event that is passed to `enqueue_retry.active_job`.
+      class EnqueueRetry < BaseEvent
+        def adapter
+          @adapter ||= @event.payload.fetch(:adapter)
+        end
+
+        def job
+          @job ||= @event.payload.fetch(:job)
+        end
+
+        def wait
+          @wait ||= @event.payload.fetch(:wait)
+        end
+
+        def error
+          @error ||= @event.payload.fetch(:error)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/active_job/log_subscriber.rb
+++ b/lib/rails_band/active_job/log_subscriber.rb
@@ -2,6 +2,7 @@
 
 require 'rails_band/active_job/event/enqueue_at'
 require 'rails_band/active_job/event/enqueue'
+require 'rails_band/active_job/event/enqueue_retry'
 
 module RailsBand
   module ActiveJob
@@ -15,6 +16,10 @@ module RailsBand
 
       def enqueue(event)
         consumer_of(__method__)&.call(Event::Enqueue.new(event))
+      end
+
+      def enqueue_retry(event)
+        consumer_of(__method__)&.call(Event::EnqueueRetry.new(event))
       end
 
       private

--- a/test/dummy/app/jobs/flaky_job.rb
+++ b/test/dummy/app/jobs/flaky_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class FlakyJob < ApplicationJob
+  class Error < StandardError; end
+
+  queue_as :default
+
+  retry_on Error, wait: 0.01.seconds, attempts: 3
+
+  def perform
+    raise Error, 'Something wrong happened!'
+  end
+end

--- a/test/rails_band/active_job/event/enqueue_retry_test.rb
+++ b/test/rails_band/active_job/event/enqueue_retry_test.rb
@@ -86,7 +86,7 @@ class EnqueueRetryTest < ActionDispatch::IntegrationTest
 
   test 'returns wait' do
     FlakyJob.perform_now
-    assert_instance_of Float, @event.wait
+    assert_kind_of Numeric, @event.wait
   end
 
   test 'returns error' do

--- a/test/rails_band/active_job/event/enqueue_retry_test.rb
+++ b/test/rails_band/active_job/event/enqueue_retry_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class EnqueueRetryTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = nil
+    RailsBand::ActiveJob::LogSubscriber.consumers = {
+      'enqueue_retry.active_job': ->(event) { @event = event }
+    }
+  end
+
+  test 'returns name' do
+    FlakyJob.perform_now
+    assert_equal 'enqueue_retry.active_job', @event.name
+  end
+
+  test 'returns time' do
+    FlakyJob.perform_now
+    assert_instance_of Float, @event.time
+  end
+
+  test 'returns end' do
+    FlakyJob.perform_now
+    assert_instance_of Float, @event.end
+  end
+
+  test 'returns transaction_id' do
+    FlakyJob.perform_now
+    assert_instance_of String, @event.transaction_id
+  end
+
+  test 'returns children' do
+    FlakyJob.perform_now
+    assert_instance_of Array, @event.children
+  end
+
+  test 'returns cpu_time' do
+    FlakyJob.perform_now
+    assert_instance_of Float, @event.cpu_time
+  end
+
+  test 'returns idle_time' do
+    FlakyJob.perform_now
+    assert_instance_of Float, @event.idle_time
+  end
+
+  test 'returns allocations' do
+    FlakyJob.perform_now
+    assert_instance_of Integer, @event.allocations
+  end
+
+  test 'returns duration' do
+    FlakyJob.perform_now
+    assert_instance_of Float, @event.duration
+  end
+
+  test 'calls #to_h' do
+    FlakyJob.perform_now
+    %i[name time end transaction_id children cpu_time idle_time allocations duration adapter job
+       wait error].each do |key|
+      assert_includes @event.to_h, key
+    end
+  end
+
+  test 'calls #slice' do
+    FlakyJob.perform_now
+    assert_equal({ name: 'enqueue_retry.active_job' }, @event.slice(:name))
+  end
+
+  test 'returns an instance of EnqueueRetry' do
+    FlakyJob.perform_now
+    assert_instance_of RailsBand::ActiveJob::Event::EnqueueRetry, @event
+  end
+
+  test 'returns adapter' do
+    FlakyJob.perform_now
+    assert_instance_of ::ActiveJob::QueueAdapters::TestAdapter, @event.adapter
+  end
+
+  test 'returns job' do
+    FlakyJob.perform_now
+    assert_instance_of FlakyJob, @event.job
+    assert_equal [], @event.job.arguments
+  end
+
+  test 'returns wait' do
+    FlakyJob.perform_now
+    assert_instance_of Float, @event.wait
+  end
+
+  test 'returns error' do
+    FlakyJob.perform_now
+    assert_instance_of FlakyJob::Error, @event.error
+  end
+end


### PR DESCRIPTION
Support [`enqueue_retry.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#enqueue-retry-active-job)