### PR TITLE
Support perform_start.active_job

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 | ------------------------------------------------------------------------------------------------------------------------- | --------- |
 | [`enqueue_at.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#enqueue-at-active-job)       | ✅        |
 | [`enqueue.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#enqueue-active-job)             | ✅        |
-| [`enqueue_retry.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#enqueue-retry-active-job) |           |
-| [`perform_start.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#perform-start-active-job) |           |
+| [`enqueue_retry.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#enqueue-retry-active-job) | ✅        |
+| [`perform_start.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#perform-start-active-job) | ✅        |
 | [`perform.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#perform-active-job)             |           |
 | [`retry_stopped.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#retry-stopped-active-job) |           |
 | [`discard.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#discard-active-job)             |           |

--- a/lib/rails_band/active_job/event/perform_start.rb
+++ b/lib/rails_band/active_job/event/perform_start.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActiveJob
+    module Event
+      # A wrapper for the event that is passed to `perform_start.active_job`.
+      class PerformStart < BaseEvent
+        def adapter
+          @adapter ||= @event.payload.fetch(:adapter)
+        end
+
+        def job
+          @job ||= @event.payload.fetch(:job)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/active_job/log_subscriber.rb
+++ b/lib/rails_band/active_job/log_subscriber.rb
@@ -3,6 +3,7 @@
 require 'rails_band/active_job/event/enqueue_at'
 require 'rails_band/active_job/event/enqueue'
 require 'rails_band/active_job/event/enqueue_retry'
+require 'rails_band/active_job/event/perform_start'
 
 module RailsBand
   module ActiveJob
@@ -20,6 +21,10 @@ module RailsBand
 
       def enqueue_retry(event)
         consumer_of(__method__)&.call(Event::EnqueueRetry.new(event))
+      end
+
+      def perform_start(event)
+        consumer_of(__method__)&.call(Event::PerformStart.new(event))
       end
 
       private

--- a/test/dummy/app/jobs/yay_job.rb
+++ b/test/dummy/app/jobs/yay_job.rb
@@ -4,6 +4,6 @@ class YayJob < ApplicationJob
   queue_as :default
 
   def perform(name:, message:)
-    p [name, message]
+    logger.info([name, message].to_json)
   end
 end

--- a/test/rails_band/active_job/event/perform_start_test.rb
+++ b/test/rails_band/active_job/event/perform_start_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PerformStartTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = nil
+    RailsBand::ActiveJob::LogSubscriber.consumers = {
+      'perform_start.active_job': ->(event) { @event = event }
+    }
+  end
+
+  test 'returns name' do
+    YayJob.perform_now(name: 'JJ', message: 'Hi')
+    assert_equal 'perform_start.active_job', @event.name
+  end
+
+  test 'returns time' do
+    YayJob.perform_now(name: 'JJ', message: 'Hi')
+    assert_instance_of Float, @event.time
+  end
+
+  test 'returns end' do
+    YayJob.perform_now(name: 'JJ', message: 'Hi')
+    assert_instance_of Float, @event.end
+  end
+
+  test 'returns transaction_id' do
+    YayJob.perform_now(name: 'JJ', message: 'Hi')
+    assert_instance_of String, @event.transaction_id
+  end
+
+  test 'returns children' do
+    YayJob.perform_now(name: 'JJ', message: 'Hi')
+    assert_instance_of Array, @event.children
+  end
+
+  test 'returns cpu_time' do
+    YayJob.perform_now(name: 'JJ', message: 'Hi')
+    assert_instance_of Float, @event.cpu_time
+  end
+
+  test 'returns idle_time' do
+    YayJob.perform_now(name: 'JJ', message: 'Hi')
+    assert_instance_of Float, @event.idle_time
+  end
+
+  test 'returns allocations' do
+    YayJob.perform_now(name: 'JJ', message: 'Hi')
+    assert_instance_of Integer, @event.allocations
+  end
+
+  test 'returns duration' do
+    YayJob.perform_now(name: 'JJ', message: 'Hi')
+    assert_instance_of Float, @event.duration
+  end
+
+  test 'calls #to_h' do
+    YayJob.perform_now(name: 'JJ', message: 'Hi')
+    %i[name time end transaction_id children cpu_time idle_time allocations duration adapter job].each do |key|
+      assert_includes @event.to_h, key
+    end
+  end
+
+  test 'calls #slice' do
+    YayJob.perform_now(name: 'JJ', message: 'Hi')
+    assert_equal({ name: 'perform_start.active_job' }, @event.slice(:name))
+  end
+
+  test 'returns an instance of PerformStart' do
+    YayJob.perform_now(name: 'JJ', message: 'Hi')
+    assert_instance_of RailsBand::ActiveJob::Event::PerformStart, @event
+  end
+
+  test 'returns adapter' do
+    YayJob.perform_now(name: 'JJ', message: 'Hi')
+    assert_instance_of ::ActiveJob::QueueAdapters::TestAdapter, @event.adapter
+  end
+
+  test 'returns job' do
+    YayJob.perform_now(name: 'JJ', message: 'Hi')
+    assert_instance_of YayJob, @event.job
+    assert_equal [{ name: 'JJ', message: 'Hi' }], @event.job.arguments
+  end
+end


### PR DESCRIPTION
Support [`perform_start.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#perform-start-active-job)