### PR TITLE
Support discard.active_job

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 | [`perform_start.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#perform-start-active-job) | ✅        |
 | [`perform.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#perform-active-job)             | ✅        |
 | [`retry_stopped.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#retry-stopped-active-job) | ✅        |
-| [`discard.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#discard-active-job)             |           |
+| [`discard.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#discard-active-job)             | ✅        |
 
 ### Action Cable
 

--- a/lib/rails_band/active_job/event/discard.rb
+++ b/lib/rails_band/active_job/event/discard.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActiveJob
+    module Event
+      # A wrapper for the event that is passed to `discard.active_job`.
+      class Discard < BaseEvent
+        def adapter
+          @adapter ||= @event.payload.fetch(:adapter)
+        end
+
+        def job
+          @job ||= @event.payload.fetch(:job)
+        end
+
+        def error
+          @error ||= @event.payload.fetch(:error)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/active_job/log_subscriber.rb
+++ b/lib/rails_band/active_job/log_subscriber.rb
@@ -6,6 +6,7 @@ require 'rails_band/active_job/event/enqueue_retry'
 require 'rails_band/active_job/event/perform_start'
 require 'rails_band/active_job/event/perform'
 require 'rails_band/active_job/event/retry_stopped'
+require 'rails_band/active_job/event/discard'
 
 module RailsBand
   module ActiveJob
@@ -35,6 +36,10 @@ module RailsBand
 
       def retry_stopped(event)
         consumer_of(__method__)&.call(Event::RetryStopped.new(event))
+      end
+
+      def discard(event)
+        consumer_of(__method__)&.call(Event::Discard.new(event))
       end
 
       private

--- a/test/dummy/app/jobs/discard_job.rb
+++ b/test/dummy/app/jobs/discard_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class DiscardJob < ApplicationJob
+  class Error < StandardError; end
+
+  queue_as :default
+
+  discard_on Error
+
+  def perform
+    raise Error, '🚮'
+  end
+end

--- a/test/rails_band/active_job/event/discard_test.rb
+++ b/test/rails_band/active_job/event/discard_test.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class DiscardTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = nil
+    RailsBand::ActiveJob::LogSubscriber.consumers = {
+      'discard.active_job': ->(event) { @event = event }
+    }
+  end
+
+  test 'returns name' do
+    perform_enqueued_jobs do
+      DiscardJob.perform_later
+    rescue DiscardJob::Error
+      assert_equal 'discard.active_job', @event.name
+    end
+  end
+
+  test 'returns time' do
+    perform_enqueued_jobs do
+      DiscardJob.perform_later
+    rescue DiscardJob::Error
+      assert_instance_of Float, @event.time
+    end
+  end
+
+  test 'returns end' do
+    perform_enqueued_jobs do
+      DiscardJob.perform_later
+    rescue DiscardJob::Error
+      assert_instance_of Float, @event.end
+    end
+  end
+
+  test 'returns transaction_id' do
+    perform_enqueued_jobs do
+      DiscardJob.perform_later
+    rescue DiscardJob::Error
+      assert_instance_of String, @event.transaction_id
+    end
+  end
+
+  test 'returns children' do
+    perform_enqueued_jobs do
+      DiscardJob.perform_later
+    rescue DiscardJob::Error
+      assert_instance_of Array, @event.children
+    end
+  end
+
+  test 'returns cpu_time' do
+    perform_enqueued_jobs do
+      DiscardJob.perform_later
+    rescue DiscardJob::Error
+      assert_instance_of Float, @event.cpu_time
+    end
+  end
+
+  test 'returns idle_time' do
+    perform_enqueued_jobs do
+      DiscardJob.perform_later
+    rescue DiscardJob::Error
+      assert_instance_of Float, @event.idle_time
+    end
+  end
+
+  test 'returns allocations' do
+    perform_enqueued_jobs do
+      DiscardJob.perform_later
+    rescue DiscardJob::Error
+      assert_instance_of Integer, @event.allocations
+    end
+  end
+
+  test 'returns duration' do
+    perform_enqueued_jobs do
+      DiscardJob.perform_later
+    rescue DiscardJob::Error
+      assert_instance_of Float, @event.duration
+    end
+  end
+
+  test 'calls #to_h' do
+    perform_enqueued_jobs do
+      DiscardJob.perform_later
+    rescue DiscardJob::Error
+      %i[name time end transaction_id children cpu_time idle_time allocations duration adapter job error].each do |key|
+        assert_includes @event.to_h, key
+      end
+    end
+  end
+
+  test 'calls #slice' do
+    perform_enqueued_jobs do
+      DiscardJob.perform_later
+    rescue DiscardJob::Error
+      assert_equal({ name: 'discard.active_job' }, @event.slice(:name))
+    end
+  end
+
+  test 'returns an instance of Discard' do
+    perform_enqueued_jobs do
+      DiscardJob.perform_later
+    rescue DiscardJob::Error
+      assert_instance_of RailsBand::ActiveJob::Event::Discard, @event
+    end
+  end
+
+  test 'returns adapter' do
+    perform_enqueued_jobs do
+      DiscardJob.perform_later
+    rescue DiscardJob::Error
+      assert_instance_of ::ActiveJob::QueueAdapters::TestAdapter, @event.adapter
+    end
+  end
+
+  test 'returns job' do
+    perform_enqueued_jobs do
+      DiscardJob.perform_later
+    rescue DiscardJob::Error
+      assert_instance_of DiscardJob, @event.job
+      assert_equal [], @event.job.arguments
+    end
+  end
+
+  test 'returns error' do
+    perform_enqueued_jobs do
+      DiscardJob.perform_later
+    rescue DiscardJob::Error
+      assert_instance_of DiscardJob::Error, @event.error
+    end
+  end
+end


### PR DESCRIPTION
Support [`discard.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#discard-active-job)