### PR TITLE
Support perform_action.action_cable

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,4 +31,8 @@ Metrics/BlockLength:
 Gemspec/RequireMFA:
   Enabled: false
 
+# I don't care the style of if/unless.
+Style/IfUnlessModifier:
+  Enabled: false
+
 # If you feel annoyed by the current configuration, let's tweak the configuration!

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 
 | Event name                                                                                                                                                              | Supported |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
-| [`perform_action.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#perform-action-action-cable)                                         |           |
+| [`perform_action.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#perform-action-action-cable)                                         | ✅        |
 | [`transmit.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#transmit-action-cable)                                                     |           |
 | [`transmit_subscription_confirmation.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#transmit-subscription-confirmation-action-cable) |           |
 | [`transmit_subscription_rejection.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#transmit-subscription-rejection-action-cable)       |           |

--- a/lib/rails_band.rb
+++ b/lib/rails_band.rb
@@ -31,4 +31,8 @@ module RailsBand
   module ActiveJob
     autoload :LogSubscriber, 'rails_band/active_job/log_subscriber'
   end
+
+  module ActionCable
+    autoload :LogSubscriber, 'rails_band/action_cable/log_subscriber'
+  end
 end

--- a/lib/rails_band/action_cable/event/perform_action.rb
+++ b/lib/rails_band/action_cable/event/perform_action.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActionCable
+    module Event
+      # A wrapper for the event that is passed to `perform_action.action_cable`.
+      class PerformAction < BaseEvent
+        def channel_class
+          @channel_class ||= @event.payload.fetch(:channel_class)
+        end
+
+        def action
+          @action ||= @event.payload.fetch(:action)
+        end
+
+        def data
+          @data ||= @event.payload.fetch(:data)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/action_cable/log_subscriber.rb
+++ b/lib/rails_band/action_cable/log_subscriber.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_band/action_cable/event/perform_action'
+
+module RailsBand
+  module ActionCable
+    # The custom LogSubscriber for ActionCable.
+    class LogSubscriber < ::ActiveSupport::LogSubscriber
+      mattr_accessor :consumers
+
+      def perform_action(event)
+        consumer_of(__method__)&.call(Event::PerformAction.new(event))
+      end
+
+      private
+
+      def consumer_of(sub_event)
+        consumers[:"#{sub_event}.action_cable"] || consumers[:action_cable] || consumers[:default]
+      end
+    end
+  end
+end

--- a/lib/rails_band/railtie.rb
+++ b/lib/rails_band/railtie.rb
@@ -30,6 +30,10 @@ module RailsBand
         swap.call(::ActionMailer::LogSubscriber, RailsBand::ActionMailer::LogSubscriber, :action_mailer)
       end
 
+      if defined?(::ActionCable)
+        RailsBand::ActionCable::LogSubscriber.attach_to :action_cable
+      end
+
       RailsBand::ActiveSupport::LogSubscriber.attach_to :active_support
 
       if defined?(::ActiveJob)

--- a/test/dummy/app/channels/application_cable/nice_channel.rb
+++ b/test/dummy/app/channels/application_cable/nice_channel.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ApplicationCable
+  class NiceChannel < ApplicationCable::Channel
+    def hello(data)
+      ActionCable.server.broadcast("nice_#{params[:number]}", data)
+    end
+
+    private
+
+    def subscribed
+      stream_from "nice_#{params[:number]}"
+    end
+  end
+end

--- a/test/rails_band/action_cable/event/perform_action_test.rb
+++ b/test/rails_band/action_cable/event/perform_action_test.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PerformActionTest < ::ActionCable::Channel::TestCase
+  tests ApplicationCable::NiceChannel
+
+  setup do
+    @event = nil
+    RailsBand::ActionCable::LogSubscriber.consumers = {
+      'perform_action.action_cable': ->(event) { @event = event }
+    }
+  end
+
+  test 'returns name' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_equal 'perform_action.action_cable', @event.name
+  end
+
+  test 'returns time' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_instance_of Float, @event.time
+  end
+
+  test 'returns end' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_instance_of Float, @event.end
+  end
+
+  test 'returns transaction_id' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_instance_of String, @event.transaction_id
+  end
+
+  test 'returns children' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_instance_of Array, @event.children
+  end
+
+  test 'returns cpu_time' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_instance_of Float, @event.cpu_time
+  end
+
+  test 'returns idle_time' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_instance_of Float, @event.idle_time
+  end
+
+  test 'returns allocations' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_instance_of Integer, @event.allocations
+  end
+
+  test 'returns duration' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_instance_of Float, @event.duration
+  end
+
+  test 'calls #to_h' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    %i[name time end transaction_id children cpu_time idle_time allocations duration
+       channel_class action data].each do |key|
+      assert_includes @event.to_h, key
+    end
+  end
+
+  test 'calls #slice' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_equal({ name: 'perform_action.action_cable' }, @event.slice(:name))
+  end
+
+  test 'returns an instance of PerformAction' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_instance_of RailsBand::ActionCable::Event::PerformAction, @event
+  end
+
+  test 'returns channel_class' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_equal 'ApplicationCable::NiceChannel', @event.channel_class
+  end
+
+  test 'returns action' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_equal :hello, @event.action
+  end
+
+  test 'returns data' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_equal({ 'name' => 'J', 'action' => 'hello' }, @event.data)
+  end
+end

--- a/test/rails_band/action_cable/log_subscriber_test.rb
+++ b/test/rails_band/action_cable/log_subscriber_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ActionCableSubscriberTest < ::ActionCable::Channel::TestCase
+  tests ApplicationCable::NiceChannel
+
+  setup do
+    @mock = Minitest::Mock.new
+    @mock.expect(:recv, nil)
+  end
+
+  test 'use the consumer with the exact event name' do
+    RailsBand::ActionCable::LogSubscriber.consumers = {
+      'perform_action.action_cable': ->(_event) { @mock.recv }
+    }
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+
+    assert_mock @mock
+  end
+
+  test 'use the consumer with namespace' do
+    RailsBand::ActionCable::LogSubscriber.consumers = {
+      action_cable: ->(event) { @mock.recv if event.name == 'perform_action.action_cable' }
+    }
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+
+    assert_mock @mock
+  end
+
+  test 'use the consumer with default' do
+    RailsBand::ActionCable::LogSubscriber.consumers = {
+      default: ->(event) { @mock.recv if event.name == 'perform_action.action_cable' }
+    }
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+
+    assert_mock @mock
+  end
+
+  test 'do not use the consumer because the event is not for the target' do
+    RailsBand::ActionCable::LogSubscriber.consumers = {
+      'unknown.action_cable': ->(_event) { @mock.recv }
+    }
+
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+
+    assert_raises MockExpectationError do
+      @mock.verify
+    end
+  end
+end


### PR DESCRIPTION
Support [perform_action.action_cable](https://guides.rubyonrails.org/active_support_instrumentation.html#perform-action-action-cable).