### PR TITLE
Support transmit.action_cable

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 | Event name                                                                                                                                                              | Supported |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
 | [`perform_action.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#perform-action-action-cable)                                         | ✅        |
-| [`transmit.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#transmit-action-cable)                                                     |           |
+| [`transmit.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#transmit-action-cable)                                                     | ✅        |
 | [`transmit_subscription_confirmation.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#transmit-subscription-confirmation-action-cable) |           |
 | [`transmit_subscription_rejection.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#transmit-subscription-rejection-action-cable)       |           |
 | [`broadcast.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#broadcast-action-cable)                                                   |           |

--- a/lib/rails_band/action_cable/event/transmit.rb
+++ b/lib/rails_band/action_cable/event/transmit.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActionCable
+    module Event
+      # A wrapper for the event that is passed to `transmit.action_cable`.
+      class Transmit < BaseEvent
+        def channel_class
+          @channel_class ||= @event.payload.fetch(:channel_class)
+        end
+
+        def data
+          @data ||= @event.payload.fetch(:data)
+        end
+
+        def via
+          @via ||= @event.payload.fetch(:via)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/action_cable/log_subscriber.rb
+++ b/lib/rails_band/action_cable/log_subscriber.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_band/action_cable/event/perform_action'
+require 'rails_band/action_cable/event/transmit'
 
 module RailsBand
   module ActionCable
@@ -10,6 +11,10 @@ module RailsBand
 
       def perform_action(event)
         consumer_of(__method__)&.call(Event::PerformAction.new(event))
+      end
+
+      def transmit(event)
+        consumer_of(__method__)&.call(Event::Transmit.new(event))
       end
 
       private

--- a/test/dummy/app/channels/application_cable/nice_channel.rb
+++ b/test/dummy/app/channels/application_cable/nice_channel.rb
@@ -6,6 +6,10 @@ module ApplicationCable
       ActionCable.server.broadcast("nice_#{params[:number]}", data)
     end
 
+    def call_transmit(data)
+      transmit data, via: 'Hi!'
+    end
+
     private
 
     def subscribed

--- a/test/rails_band/action_cable/event/transmit_test.rb
+++ b/test/rails_band/action_cable/event/transmit_test.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TransmitTest < ::ActionCable::Channel::TestCase
+  tests ApplicationCable::NiceChannel
+
+  setup do
+    @event = nil
+    RailsBand::ActionCable::LogSubscriber.consumers = {
+      'transmit.action_cable': ->(event) { @event = event }
+    }
+  end
+
+  test 'returns name' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_equal 'transmit.action_cable', @event.name
+  end
+
+  test 'returns time' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_instance_of Float, @event.time
+  end
+
+  test 'returns end' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_instance_of Float, @event.end
+  end
+
+  test 'returns transaction_id' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_instance_of String, @event.transaction_id
+  end
+
+  test 'returns children' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_instance_of Array, @event.children
+  end
+
+  test 'returns cpu_time' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_instance_of Float, @event.cpu_time
+  end
+
+  test 'returns idle_time' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_instance_of Float, @event.idle_time
+  end
+
+  test 'returns allocations' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_instance_of Integer, @event.allocations
+  end
+
+  test 'returns duration' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_instance_of Float, @event.duration
+  end
+
+  test 'calls #to_h' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    %i[name time end transaction_id children cpu_time idle_time allocations duration
+       channel_class data via].each do |key|
+      assert_includes @event.to_h, key
+    end
+  end
+
+  test 'calls #slice' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_equal({ name: 'transmit.action_cable' }, @event.slice(:name))
+  end
+
+  test 'returns an instance of Transmit' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_instance_of RailsBand::ActionCable::Event::Transmit, @event
+  end
+
+  test 'returns channel_class' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_equal 'ApplicationCable::NiceChannel', @event.channel_class
+  end
+
+  test 'returns data' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_equal({ 'name' => 'J', 'action' => 'call_transmit' }, @event.data)
+  end
+
+  test 'returns via' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_equal 'Hi!', @event.via
+  end
+end


### PR DESCRIPTION
Support [`transmit.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#transmit-action-cable).