### PR TITLE
Support transmit_subscription_confirmation.action_cable

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
 | [`perform_action.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#perform-action-action-cable)                                         | ✅        |
 | [`transmit.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#transmit-action-cable)                                                     | ✅        |
-| [`transmit_subscription_confirmation.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#transmit-subscription-confirmation-action-cable) |           |
+| [`transmit_subscription_confirmation.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#transmit-subscription-confirmation-action-cable) | ✅        |
 | [`transmit_subscription_rejection.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#transmit-subscription-rejection-action-cable)       |           |
 | [`broadcast.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#broadcast-action-cable)                                                   |           |
 

--- a/lib/rails_band/action_cable/event/transmit_subscription_confirmation.rb
+++ b/lib/rails_band/action_cable/event/transmit_subscription_confirmation.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActionCable
+    module Event
+      # A wrapper for the event that is passed to `transmit_subscription_confirmation.action_cable`.
+      class TransmitSubscriptionConfirmation < BaseEvent
+        def channel_class
+          @channel_class ||= @event.payload.fetch(:channel_class)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/action_cable/log_subscriber.rb
+++ b/lib/rails_band/action_cable/log_subscriber.rb
@@ -2,6 +2,7 @@
 
 require 'rails_band/action_cable/event/perform_action'
 require 'rails_band/action_cable/event/transmit'
+require 'rails_band/action_cable/event/transmit_subscription_confirmation'
 
 module RailsBand
   module ActionCable
@@ -15,6 +16,10 @@ module RailsBand
 
       def transmit(event)
         consumer_of(__method__)&.call(Event::Transmit.new(event))
+      end
+
+      def transmit_subscription_confirmation(event)
+        consumer_of(__method__)&.call(Event::TransmitSubscriptionConfirmation.new(event))
       end
 
       private

--- a/test/rails_band/action_cable/event/transmit_subscription_confirmation_test.rb
+++ b/test/rails_band/action_cable/event/transmit_subscription_confirmation_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TransmitSubscriptionConfirmationTest < ::ActionCable::Channel::TestCase
+  tests ApplicationCable::NiceChannel
+
+  setup do
+    @event = nil
+    RailsBand::ActionCable::LogSubscriber.consumers = {
+      'transmit_subscription_confirmation.action_cable': ->(event) { @event = event }
+    }
+  end
+
+  test 'returns name' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_equal 'transmit_subscription_confirmation.action_cable', @event.name
+  end
+
+  test 'returns time' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_instance_of Float, @event.time
+  end
+
+  test 'returns end' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_instance_of Float, @event.end
+  end
+
+  test 'returns transaction_id' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_instance_of String, @event.transaction_id
+  end
+
+  test 'returns children' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_instance_of Array, @event.children
+  end
+
+  test 'returns cpu_time' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_instance_of Float, @event.cpu_time
+  end
+
+  test 'returns idle_time' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_instance_of Float, @event.idle_time
+  end
+
+  test 'returns allocations' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_instance_of Integer, @event.allocations
+  end
+
+  test 'returns duration' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_instance_of Float, @event.duration
+  end
+
+  test 'calls #to_h' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    %i[name time end transaction_id children cpu_time idle_time allocations duration channel_class].each do |key|
+      assert_includes @event.to_h, key
+    end
+  end
+
+  test 'calls #slice' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_equal({ name: 'transmit_subscription_confirmation.action_cable' }, @event.slice(:name))
+  end
+
+  test 'returns an instance of TransmitSubscriptionConfirmation' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_instance_of RailsBand::ActionCable::Event::TransmitSubscriptionConfirmation, @event
+  end
+
+  test 'returns channel_class' do
+    subscribe number: '2'
+    perform :call_transmit, { name: 'J' }
+    assert_equal 'ApplicationCable::NiceChannel', @event.channel_class
+  end
+end


### PR DESCRIPTION
Support [`transmit_subscription_confirmation.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#transmit-subscription-confirmation-action-cable)