### PR TITLE
Support transmit_subscription_rejection.action_cable

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 | [`perform_action.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#perform-action-action-cable)                                         | ✅        |
 | [`transmit.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#transmit-action-cable)                                                     | ✅        |
 | [`transmit_subscription_confirmation.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#transmit-subscription-confirmation-action-cable) | ✅        |
-| [`transmit_subscription_rejection.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#transmit-subscription-rejection-action-cable)       |           |
+| [`transmit_subscription_rejection.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#transmit-subscription-rejection-action-cable)       | ✅        |
 | [`broadcast.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#broadcast-action-cable)                                                   |           |
 
 ### Active Storage

--- a/lib/rails_band/action_cable/event/transmit_subscription_rejection.rb
+++ b/lib/rails_band/action_cable/event/transmit_subscription_rejection.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActionCable
+    module Event
+      # A wrapper for the event that is passed to `transmit_subscription_rejection.action_cable`.
+      class TransmitSubscriptionRejection < BaseEvent
+        def channel_class
+          @channel_class ||= @event.payload.fetch(:channel_class)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/action_cable/log_subscriber.rb
+++ b/lib/rails_band/action_cable/log_subscriber.rb
@@ -3,6 +3,7 @@
 require 'rails_band/action_cable/event/perform_action'
 require 'rails_band/action_cable/event/transmit'
 require 'rails_band/action_cable/event/transmit_subscription_confirmation'
+require 'rails_band/action_cable/event/transmit_subscription_rejection'
 
 module RailsBand
   module ActionCable
@@ -20,6 +21,10 @@ module RailsBand
 
       def transmit_subscription_confirmation(event)
         consumer_of(__method__)&.call(Event::TransmitSubscriptionConfirmation.new(event))
+      end
+
+      def transmit_subscription_rejection(event)
+        consumer_of(__method__)&.call(Event::TransmitSubscriptionRejection.new(event))
       end
 
       private

--- a/test/dummy/app/channels/application_cable/nice_channel.rb
+++ b/test/dummy/app/channels/application_cable/nice_channel.rb
@@ -14,6 +14,7 @@ module ApplicationCable
 
     def subscribed
       stream_from "nice_#{params[:number]}"
+      reject if Integer(params[:number], exception: false).negative?
     end
   end
 end

--- a/test/rails_band/action_cable/event/transmit_subscription_rejection_test.rb
+++ b/test/rails_band/action_cable/event/transmit_subscription_rejection_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TransmitSubscriptionRejectionTest < ::ActionCable::Channel::TestCase
+  tests ApplicationCable::NiceChannel
+
+  setup do
+    @event = nil
+    RailsBand::ActionCable::LogSubscriber.consumers = {
+      'transmit_subscription_rejection.action_cable': ->(event) { @event = event }
+    }
+  end
+
+  test 'returns name' do
+    subscribe number: '-3'
+    assert_equal 'transmit_subscription_rejection.action_cable', @event.name
+  end
+
+  test 'returns time' do
+    subscribe number: '-3'
+    assert_instance_of Float, @event.time
+  end
+
+  test 'returns end' do
+    subscribe number: '-3'
+    assert_instance_of Float, @event.end
+  end
+
+  test 'returns transaction_id' do
+    subscribe number: '-3'
+    assert_instance_of String, @event.transaction_id
+  end
+
+  test 'returns children' do
+    subscribe number: '-3'
+    assert_instance_of Array, @event.children
+  end
+
+  test 'returns cpu_time' do
+    subscribe number: '-3'
+    assert_instance_of Float, @event.cpu_time
+  end
+
+  test 'returns idle_time' do
+    subscribe number: '-3'
+    assert_instance_of Float, @event.idle_time
+  end
+
+  test 'returns allocations' do
+    subscribe number: '-3'
+    assert_instance_of Integer, @event.allocations
+  end
+
+  test 'returns duration' do
+    subscribe number: '-3'
+    assert_instance_of Float, @event.duration
+  end
+
+  test 'calls #to_h' do
+    subscribe number: '-3'
+    %i[name time end transaction_id children cpu_time idle_time allocations duration channel_class].each do |key|
+      assert_includes @event.to_h, key
+    end
+  end
+
+  test 'calls #slice' do
+    subscribe number: '-3'
+    assert_equal({ name: 'transmit_subscription_rejection.action_cable' }, @event.slice(:name))
+  end
+
+  test 'returns an instance of TransmitSubscriptionRejection' do
+    subscribe number: '-3'
+    assert_instance_of RailsBand::ActionCable::Event::TransmitSubscriptionRejection, @event
+  end
+
+  test 'returns channel_class' do
+    subscribe number: '-3'
+    assert_equal 'ApplicationCable::NiceChannel', @event.channel_class
+  end
+end


### PR DESCRIPTION
Support [`transmit_subscription_rejection.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#transmit-subscription-rejection-action-cable)