### PR TITLE
Support broadcast.action_cable

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 | [`transmit.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#transmit-action-cable)                                                     | ✅        |
 | [`transmit_subscription_confirmation.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#transmit-subscription-confirmation-action-cable) | ✅        |
 | [`transmit_subscription_rejection.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#transmit-subscription-rejection-action-cable)       | ✅        |
-| [`broadcast.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#broadcast-action-cable)                                                   |           |
+| [`broadcast.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#broadcast-action-cable)                                                   | ✅        |
 
 ### Active Storage
 

--- a/lib/rails_band/action_cable/event/broadcast.rb
+++ b/lib/rails_band/action_cable/event/broadcast.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActionCable
+    module Event
+      # A wrapper for the event that is passed to `broadcast.action_cable`.
+      class Broadcast < BaseEvent
+        def broadcasting
+          @broadcasting ||= @event.payload.fetch(:broadcasting)
+        end
+
+        def message
+          @message ||= @event.payload.fetch(:message)
+        end
+
+        def coder
+          @coder ||= @event.payload.fetch(:coder)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/action_cable/log_subscriber.rb
+++ b/lib/rails_band/action_cable/log_subscriber.rb
@@ -4,6 +4,7 @@ require 'rails_band/action_cable/event/perform_action'
 require 'rails_band/action_cable/event/transmit'
 require 'rails_band/action_cable/event/transmit_subscription_confirmation'
 require 'rails_band/action_cable/event/transmit_subscription_rejection'
+require 'rails_band/action_cable/event/broadcast'
 
 module RailsBand
   module ActionCable
@@ -25,6 +26,10 @@ module RailsBand
 
       def transmit_subscription_rejection(event)
         consumer_of(__method__)&.call(Event::TransmitSubscriptionRejection.new(event))
+      end
+
+      def broadcast(event)
+        consumer_of(__method__)&.call(Event::Broadcast.new(event))
       end
 
       private

--- a/test/rails_band/action_cable/event/broadcast_test.rb
+++ b/test/rails_band/action_cable/event/broadcast_test.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class BroadcastTest < ::ActionCable::Channel::TestCase
+  tests ApplicationCable::NiceChannel
+
+  setup do
+    @event = nil
+    RailsBand::ActionCable::LogSubscriber.consumers = {
+      'broadcast.action_cable': ->(event) { @event = event }
+    }
+  end
+
+  test 'returns name' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_equal 'broadcast.action_cable', @event.name
+  end
+
+  test 'returns time' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_instance_of Float, @event.time
+  end
+
+  test 'returns end' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_instance_of Float, @event.end
+  end
+
+  test 'returns transaction_id' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_instance_of String, @event.transaction_id
+  end
+
+  test 'returns children' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_instance_of Array, @event.children
+  end
+
+  test 'returns cpu_time' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_instance_of Float, @event.cpu_time
+  end
+
+  test 'returns idle_time' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_instance_of Float, @event.idle_time
+  end
+
+  test 'returns allocations' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_instance_of Integer, @event.allocations
+  end
+
+  test 'returns duration' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_instance_of Float, @event.duration
+  end
+
+  test 'calls #to_h' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    %i[name time end transaction_id children cpu_time idle_time allocations duration broadcasting message
+       coder].each do |key|
+      assert_includes @event.to_h, key
+    end
+  end
+
+  test 'calls #slice' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_equal({ name: 'broadcast.action_cable' }, @event.slice(:name))
+  end
+
+  test 'returns an instance of Broadcast' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_instance_of RailsBand::ActionCable::Event::Broadcast, @event
+  end
+
+  test 'returns broadcasting' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_equal 'nice_2', @event.broadcasting
+  end
+
+  test 'returns message' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_equal({ 'name' => 'J', 'action' => 'hello' }, @event.message)
+  end
+
+  test 'returns coder' do
+    subscribe number: '2'
+    perform :hello, { name: 'J' }
+    assert_equal ActiveSupport::JSON, @event.coder
+  end
+end


### PR DESCRIPTION
Support [`broadcast.action_cable`](https://guides.rubyonrails.org/active_support_instrumentation.html#broadcast-action-cable)