### PR TITLE
Support service_download_chunk.active_storage

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,10 @@ AllCops:
     - 'vendor/**/*'
     - '**/*_create_active_storage_tables.active_storage.rb'
 
+Metrics/AbcSize:
+  Exclude:
+    - 'test/dummy/**/*.rb'
+
 Metrics/ClassLength:
   Exclude:
     - 'test/**/*_test.rb'

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
 | [`service_upload.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-upload-active-storage)                         | ✅        |
 | [`service_streaming_download.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-streaming-download-active-storage) | ✅        |
-| [`service_download_chunk.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-download-chunk-active-storage)         |           |
+| [`service_download_chunk.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-download-chunk-active-storage)         | ✅        |
 | [`service_download.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-download-active-storage)                     |           |
 | [`service_delete.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-delete-active-storage)                         |           |
 | [`service_delete_prefixed.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-delete-prefixed-active-storage)       |           |

--- a/lib/rails_band/active_storage/event/service_download_chunk.rb
+++ b/lib/rails_band/active_storage/event/service_download_chunk.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActiveStorage
+    module Event
+      # A wrapper for the event that is passed to `service_download_chunk.active_storage`.
+      class ServiceDownloadChunk < BaseEvent
+        def key
+          return @key if defined? @key
+
+          @key = @event.payload[:key]
+        end
+
+        def service
+          @service ||= @event.payload.fetch(:service)
+        end
+
+        def range
+          @range ||= @event.payload.fetch(:range)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/active_storage/log_subscriber.rb
+++ b/lib/rails_band/active_storage/log_subscriber.rb
@@ -2,6 +2,7 @@
 
 require 'rails_band/active_storage/event/service_upload'
 require 'rails_band/active_storage/event/service_streaming_download'
+require 'rails_band/active_storage/event/service_download_chunk'
 
 module RailsBand
   module ActiveStorage
@@ -15,6 +16,10 @@ module RailsBand
 
       def service_streaming_download(event)
         consumer_of(__method__)&.call(Event::ServiceStreamingDownload.new(event))
+      end
+
+      def service_download_chunk(event)
+        consumer_of(__method__)&.call(Event::ServiceDownloadChunk.new(event))
       end
 
       private

--- a/test/dummy/app/controllers/teams_controller.rb
+++ b/test/dummy/app/controllers/teams_controller.rb
@@ -6,7 +6,8 @@ class TeamsController < ApplicationController
     team.avatar.download do |data|
       logger.debug(data.size)
     end
-    team.avatar.blob.download_chunk(0...40) do |data|
+    service = Gem::Version.new(Rails.version) >= Gem::Version.new('7.0') ? team.avatar.blob : team.avatar.service
+    service.download_chunk(0...40) do |data|
       logger.debug(data.size)
     end
     redirect_to team_path(team)

--- a/test/dummy/app/controllers/teams_controller.rb
+++ b/test/dummy/app/controllers/teams_controller.rb
@@ -6,7 +6,7 @@ class TeamsController < ApplicationController
     team.avatar.download do |data|
       logger.debug(data.size)
     end
-    team.avatar.attachment.download_chunk(0...40) do |data|
+    team.avatar.blob.download_chunk(0...40) do |data|
       logger.debug(data.size)
     end
     redirect_to team_path(team)

--- a/test/dummy/app/controllers/teams_controller.rb
+++ b/test/dummy/app/controllers/teams_controller.rb
@@ -6,8 +6,8 @@ class TeamsController < ApplicationController
     team.avatar.download do |data|
       logger.debug(data.size)
     end
-    service = Gem::Version.new(Rails.version) >= Gem::Version.new('7.0') ? team.avatar.blob : team.avatar.service
-    service.download_chunk(0...40) do |data|
+    service = ActiveStorage::Blob.service
+    service.download_chunk(team.avatar.blob.key, 0...40) do |data|
       logger.debug(data.size)
     end
     redirect_to team_path(team)

--- a/test/dummy/app/controllers/teams_controller.rb
+++ b/test/dummy/app/controllers/teams_controller.rb
@@ -6,7 +6,7 @@ class TeamsController < ApplicationController
     team.avatar.download do |data|
       logger.debug(data.size)
     end
-    team.avatar.download_chunk(0...40) do |data|
+    team.avatar.attachment.download_chunk(0...40) do |data|
       logger.debug(data.size)
     end
     redirect_to team_path(team)

--- a/test/dummy/app/controllers/teams_controller.rb
+++ b/test/dummy/app/controllers/teams_controller.rb
@@ -6,6 +6,9 @@ class TeamsController < ApplicationController
     team.avatar.download do |data|
       logger.debug(data.size)
     end
+    team.avatar.download_chunk(0...40) do |data|
+      logger.debug(data.size)
+    end
     redirect_to team_path(team)
   end
 end

--- a/test/rails_band/active_storage/event/service_download_chunk_test.rb
+++ b/test/rails_band/active_storage/event/service_download_chunk_test.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ServiceDownloadChunkTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = nil
+    RailsBand::ActiveStorage::LogSubscriber.consumers = {
+      'service_download_chunk.active_storage': ->(event) { @event = event }
+    }
+  end
+
+  test 'returns name' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_equal 'service_download_chunk.active_storage', @event.name
+  end
+
+  test 'returns time' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Float, @event.time
+  end
+
+  test 'returns end' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Float, @event.end
+  end
+
+  test 'returns transaction_id' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of String, @event.transaction_id
+  end
+
+  test 'returns children' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Array, @event.children
+  end
+
+  test 'returns cpu_time' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Float, @event.cpu_time
+  end
+
+  test 'returns idle_time' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Float, @event.idle_time
+  end
+
+  test 'returns allocations' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Integer, @event.allocations
+  end
+
+  test 'returns duration' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Float, @event.duration
+  end
+
+  test 'calls #to_h' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    %i[name time end transaction_id children cpu_time idle_time allocations duration key service range].each do |key|
+      assert_includes @event.to_h, key
+    end
+  end
+
+  test 'calls #slice' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_equal({ name: 'service_download_chunk.active_storage' }, @event.slice(:name))
+  end
+
+  test 'returns an instance of ServiceUpload' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of RailsBand::ActiveStorage::Event::ServiceDownloadChunk, @event
+  end
+
+  test 'returns the key' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_respond_to @event, :key
+  end
+
+  test 'returns the service' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_equal 'Disk', @event.service
+  end
+
+  test 'returns the range' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_equal 0...40, @event.range
+  end
+end


### PR DESCRIPTION
Support [service_download_chunk.active_storage](https://guides.rubyonrails.org/active_support_instrumentation.html#service-download-chunk-active-storage)