### PR TITLE
Support service_download.active_storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 | [`service_upload.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-upload-active-storage)                         | ✅        |
 | [`service_streaming_download.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-streaming-download-active-storage) | ✅        |
 | [`service_download_chunk.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-download-chunk-active-storage)         | ✅        |
-| [`service_download.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-download-active-storage)                     |           |
+| [`service_download.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-download-active-storage)                     | ✅        |
 | [`service_delete.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-delete-active-storage)                         |           |
 | [`service_delete_prefixed.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-delete-prefixed-active-storage)       |           |
 | [`service_exist.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-exist-active-storage)                           |           |

--- a/lib/rails_band/active_storage/event/service_download.rb
+++ b/lib/rails_band/active_storage/event/service_download.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActiveStorage
+    module Event
+      # A wrapper for the event that is passed to `service_download.active_storage`.
+      class ServiceDownload < BaseEvent
+        def key
+          return @key if defined? @key
+
+          @key = @event.payload[:key]
+        end
+
+        def service
+          @service ||= @event.payload.fetch(:service)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/active_storage/log_subscriber.rb
+++ b/lib/rails_band/active_storage/log_subscriber.rb
@@ -3,6 +3,7 @@
 require 'rails_band/active_storage/event/service_upload'
 require 'rails_band/active_storage/event/service_streaming_download'
 require 'rails_band/active_storage/event/service_download_chunk'
+require 'rails_band/active_storage/event/service_download'
 
 module RailsBand
   module ActiveStorage
@@ -20,6 +21,10 @@ module RailsBand
 
       def service_download_chunk(event)
         consumer_of(__method__)&.call(Event::ServiceDownloadChunk.new(event))
+      end
+
+      def service_download(event)
+        consumer_of(__method__)&.call(Event::ServiceDownload.new(event))
       end
 
       private

--- a/test/dummy/app/controllers/teams_controller.rb
+++ b/test/dummy/app/controllers/teams_controller.rb
@@ -4,8 +4,13 @@ class TeamsController < ApplicationController
   def create
     team = Team.create!(params.require(:team).permit(:name, :avatar))
     team.avatar.download do |data|
+      # For service_streaming_download
       logger.debug(data.size)
     end
+
+    # For service_download
+    team.avatar.download
+
     service = ActiveStorage::Blob.service
     service.download_chunk(team.avatar.blob.key, 0...40) do |data|
       logger.debug(data.size)

--- a/test/rails_band/active_storage/event/service_download_test.rb
+++ b/test/rails_band/active_storage/event/service_download_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ServiceDownloadTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = nil
+    RailsBand::ActiveStorage::LogSubscriber.consumers = {
+      'service_download.active_storage': ->(event) { @event = event }
+    }
+  end
+
+  test 'returns name' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_equal 'service_download.active_storage', @event.name
+  end
+
+  test 'returns time' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Float, @event.time
+  end
+
+  test 'returns end' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Float, @event.end
+  end
+
+  test 'returns transaction_id' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of String, @event.transaction_id
+  end
+
+  test 'returns children' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Array, @event.children
+  end
+
+  test 'returns cpu_time' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Float, @event.cpu_time
+  end
+
+  test 'returns idle_time' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Float, @event.idle_time
+  end
+
+  test 'returns allocations' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Integer, @event.allocations
+  end
+
+  test 'returns duration' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Float, @event.duration
+  end
+
+  test 'calls #to_h' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    %i[name time end transaction_id children cpu_time idle_time allocations duration key service].each do |key|
+      assert_includes @event.to_h, key
+    end
+  end
+
+  test 'calls #slice' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_equal({ name: 'service_download.active_storage' }, @event.slice(:name))
+  end
+
+  test 'returns an instance of ServiceUpload' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of RailsBand::ActiveStorage::Event::ServiceDownload, @event
+  end
+
+  test 'returns the key' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_respond_to @event, :key
+  end
+
+  test 'returns the service' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_equal 'Disk', @event.service
+  end
+end


### PR DESCRIPTION
Support [service_download.active_storage](https://guides.rubyonrails.org/active_support_instrumentation.html#service-download-active-storage)