### PR TITLE
Support service_delete_prefixed.active_storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 | [`service_download_chunk.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-download-chunk-active-storage)         | ✅        |
 | [`service_download.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-download-active-storage)                     | ✅        |
 | [`service_delete.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-delete-active-storage)                         | ✅        |
-| [`service_delete_prefixed.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-delete-prefixed-active-storage)       |           |
+| [`service_delete_prefixed.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-delete-prefixed-active-storage)       | ✅        |
 | [`service_exist.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-exist-active-storage)                           |           |
 | [`service_url.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-url-active-storage)                               |           |
 | [`service_update_metadata.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-update-metadata-active-storage)       |           |

--- a/lib/rails_band/active_storage/event/service_delete_prefixed.rb
+++ b/lib/rails_band/active_storage/event/service_delete_prefixed.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActiveStorage
+    module Event
+      # A wrapper for the event that is passed to `service_delete_prefixed.active_storage`.
+      class ServiceDeletePrefixed < BaseEvent
+        def prefix
+          @prefix ||= @event.payload.fetch(:prefix)
+        end
+
+        def service
+          @service ||= @event.payload.fetch(:service)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/active_storage/log_subscriber.rb
+++ b/lib/rails_band/active_storage/log_subscriber.rb
@@ -5,6 +5,7 @@ require 'rails_band/active_storage/event/service_streaming_download'
 require 'rails_band/active_storage/event/service_download_chunk'
 require 'rails_band/active_storage/event/service_download'
 require 'rails_band/active_storage/event/service_delete'
+require 'rails_band/active_storage/event/service_delete_prefixed'
 
 module RailsBand
   module ActiveStorage
@@ -30,6 +31,10 @@ module RailsBand
 
       def service_delete(event)
         consumer_of(__method__)&.call(Event::ServiceDelete.new(event))
+      end
+
+      def service_delete_prefixed(event)
+        consumer_of(__method__)&.call(Event::ServiceDeletePrefixed.new(event))
       end
 
       private

--- a/test/dummy/app/controllers/teams_controller.rb
+++ b/test/dummy/app/controllers/teams_controller.rb
@@ -20,6 +20,9 @@ class TeamsController < ApplicationController
     # For service_delete
     service.delete(team.avatar.blob.key)
 
+    # For service_delete_prefixed
+    service.delete_prefixed('my-prefix')
+
     redirect_to team_path(team)
   end
 end

--- a/test/rails_band/active_storage/event/service_delete_prefixed_test.rb
+++ b/test/rails_band/active_storage/event/service_delete_prefixed_test.rb
@@ -74,7 +74,7 @@ class ServiceDeletePrefixedTest < ActionDispatch::IntegrationTest
 
   test 'returns the prefix' do
     post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
-    assert_equal @event.prefix, 'my-prefix'
+    assert_equal 'my-prefix', @event.prefix
   end
 
   test 'returns the service' do

--- a/test/rails_band/active_storage/event/service_delete_prefixed_test.rb
+++ b/test/rails_band/active_storage/event/service_delete_prefixed_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ServiceDeletePrefixedTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = nil
+    RailsBand::ActiveStorage::LogSubscriber.consumers = {
+      'service_delete_prefixed.active_storage': ->(event) { @event = event }
+    }
+  end
+
+  test 'returns name' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_equal 'service_delete_prefixed.active_storage', @event.name
+  end
+
+  test 'returns time' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Float, @event.time
+  end
+
+  test 'returns end' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Float, @event.end
+  end
+
+  test 'returns transaction_id' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of String, @event.transaction_id
+  end
+
+  test 'returns children' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Array, @event.children
+  end
+
+  test 'returns cpu_time' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Float, @event.cpu_time
+  end
+
+  test 'returns idle_time' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Float, @event.idle_time
+  end
+
+  test 'returns allocations' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Integer, @event.allocations
+  end
+
+  test 'returns duration' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Float, @event.duration
+  end
+
+  test 'calls #to_h' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    %i[name time end transaction_id children cpu_time idle_time allocations duration prefix service].each do |key|
+      assert_includes @event.to_h, key
+    end
+  end
+
+  test 'calls #slice' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_equal({ name: 'service_delete_prefixed.active_storage' }, @event.slice(:name))
+  end
+
+  test 'returns an instance of ServiceUpload' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of RailsBand::ActiveStorage::Event::ServiceDeletePrefixed, @event
+  end
+
+  test 'returns the prefix' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_equal @event.prefix, 'my-prefix'
+  end
+
+  test 'returns the service' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_equal 'Disk', @event.service
+  end
+end


### PR DESCRIPTION
Support [service_delete_prefixed.active_storage](https://guides.rubyonrails.org/active_support_instrumentation.html#service-delete-prefixed-active-storage)