### PR TITLE
Support service_update_metadata.active_storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 | [`service_delete_prefixed.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-delete-prefixed-active-storage)       | ✅        |
 | [`service_exist.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-exist-active-storage)                           | ✅        |
 | [`service_url.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-url-active-storage)                               | ✅        |
-| [`service_update_metadata.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-update-metadata-active-storage)       |           |
+| [`service_update_metadata.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#service-update-metadata-active-storage)       | ✅        |
 | [`preview.active_storage`](https://guides.rubyonrails.org/active_support_instrumentation.html#preview-active-storage)                                       |           |
 | [`analyze.active_storage`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#analyze-active-storage)                                   |           |
 

--- a/lib/rails_band/active_storage/event/service_update_metadata.rb
+++ b/lib/rails_band/active_storage/event/service_update_metadata.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActiveStorage
+    module Event
+      # A wrapper for the event that is passed to `service_update_metadata.active_storage`.
+      class ServiceUpdateMetadata < BaseEvent
+        def key
+          return @key if defined? @key
+
+          @key = @event.payload[:key]
+        end
+
+        def service
+          @service ||= @event.payload.fetch(:service)
+        end
+
+        def content_type
+          @content_type ||= @event.payload.fetch(:content_type)
+        end
+
+        def disposition
+          @disposition ||= @event.payload.fetch(:disposition)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/active_storage/log_subscriber.rb
+++ b/lib/rails_band/active_storage/log_subscriber.rb
@@ -8,6 +8,7 @@ require 'rails_band/active_storage/event/service_delete'
 require 'rails_band/active_storage/event/service_delete_prefixed'
 require 'rails_band/active_storage/event/service_exist'
 require 'rails_band/active_storage/event/service_url'
+require 'rails_band/active_storage/event/service_update_metadata'
 
 module RailsBand
   module ActiveStorage
@@ -45,6 +46,10 @@ module RailsBand
 
       def service_url(event)
         consumer_of(__method__)&.call(Event::ServiceUrl.new(event))
+      end
+
+      def service_update_metadata(event)
+        consumer_of(__method__)&.call(Event::ServiceUpdateMetadata.new(event))
       end
 
       private

--- a/test/dummy/app/controllers/teams_controller.rb
+++ b/test/dummy/app/controllers/teams_controller.rb
@@ -35,6 +35,17 @@ class TeamsController < ApplicationController
     # For service_exist
     service.exist?(team.avatar.blob.key)
 
+    # HACK: service_update_metadata.active_storage is supported in GCS service only, so this test imitates the behavior.
+    payload = {
+      key: 'my-key',
+      service: 'Disk',
+      content_type: 'Content-Type!',
+      disposition: 'Disposition',
+    }
+    ActiveSupport::Notifications.instrument('service_update_metadata.active_storage', **payload) do
+      logger.debug(payload)
+    end
+
     redirect_to team_path(team)
   end
 end

--- a/test/dummy/app/controllers/teams_controller.rb
+++ b/test/dummy/app/controllers/teams_controller.rb
@@ -40,7 +40,7 @@ class TeamsController < ApplicationController
       key: 'my-key',
       service: 'Disk',
       content_type: 'Content-Type!',
-      disposition: 'Disposition',
+      disposition: 'Disposition'
     }
     ActiveSupport::Notifications.instrument('service_update_metadata.active_storage', **payload) do
       logger.debug(payload)

--- a/test/rails_band/active_storage/event/service_update_metadata_test.rb
+++ b/test/rails_band/active_storage/event/service_update_metadata_test.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ServiceUpdateMetadataTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = nil
+    RailsBand::ActiveStorage::LogSubscriber.consumers = {
+      'service_update_metadata.active_storage': ->(event) { @event = event }
+    }
+  end
+
+  test 'returns name' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_equal 'service_update_metadata.active_storage', @event.name
+  end
+
+  test 'returns time' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Float, @event.time
+  end
+
+  test 'returns end' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Float, @event.end
+  end
+
+  test 'returns transaction_id' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of String, @event.transaction_id
+  end
+
+  test 'returns children' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Array, @event.children
+  end
+
+  test 'returns cpu_time' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Float, @event.cpu_time
+  end
+
+  test 'returns idle_time' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Float, @event.idle_time
+  end
+
+  test 'returns allocations' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Integer, @event.allocations
+  end
+
+  test 'returns duration' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of Float, @event.duration
+  end
+
+  test 'calls #to_h' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    %i[name time end transaction_id children cpu_time idle_time allocations duration key service
+       content_type disposition].each do |key|
+      assert_includes @event.to_h, key
+    end
+  end
+
+  test 'calls #slice' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_equal({ name: 'service_update_metadata.active_storage' }, @event.slice(:name))
+  end
+
+  test 'returns an instance of ServiceUpload' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_instance_of RailsBand::ActiveStorage::Event::ServiceUpdateMetadata, @event
+  end
+
+  test 'returns the key' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_respond_to @event, :key
+  end
+
+  test 'returns the service' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_equal 'Disk', @event.service
+  end
+
+  test 'returns the content_type' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_equal 'Content-Type!', @event.content_type
+  end
+
+  test 'returns the disposition' do
+    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
+    assert_equal 'Disposition', @event.disposition
+  end
+end


### PR DESCRIPTION
Support [service_update_metadata.active_storage](https://guides.rubyonrails.org/active_support_instrumentation.html#service-update-metadata-active-storage)