### PR TITLE
Fix Railtie to set consumers without #swap

### DIFF
--- a/lib/rails_band/railtie.rb
+++ b/lib/rails_band/railtie.rb
@@ -31,13 +31,16 @@ module RailsBand
       end
 
       if defined?(::ActionCable)
+        RailsBand::ActionCable::LogSubscriber.consumers = consumers
         RailsBand::ActionCable::LogSubscriber.attach_to :action_cable
       end
 
       if defined?(::ActiveStorage)
+        RailsBand::ActiveStorage::LogSubscriber.consumers = consumers
         RailsBand::ActiveStorage::LogSubscriber.attach_to :active_storage
       end
 
+      RailsBand::ActiveSupport::LogSubscriber.consumers = consumers
       RailsBand::ActiveSupport::LogSubscriber.attach_to :active_support
 
       if defined?(::ActiveJob)


### PR DESCRIPTION
Some subscribers are not defined in Rails, so we don't have to use `swap` to replace the existing subscribers. However, such subscribers must set `consumers` explicitly, but I forgot to set it.

This fix set `consumers` for `RailsBand::ActionCable::LogSubscriber`, `RailsBand::ActiveStorage::LogSubscriber`, and `RailsBand::ActiveSupport::LogSubscriber`.