### PR TITLE
Support deprecation.rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 
 | Event name                                                                                                  | Supported |
 | ----------------------------------------------------------------------------------------------------------- | --------- |
-| [`deprecation.rails`](https://guides.rubyonrails.org/active_support_instrumentation.html#deprecation-rails) |           |
+| [`deprecation.rails`](https://guides.rubyonrails.org/active_support_instrumentation.html#deprecation-rails) | ✅        |
 
 ## Contributing
 

--- a/lib/rails_band.rb
+++ b/lib/rails_band.rb
@@ -3,6 +3,7 @@
 require 'rails_band/version'
 require 'rails_band/configuration'
 require 'rails_band/base_event'
+require 'rails_band/deprecation_subscriber'
 require 'rails_band/railtie'
 
 # Rails::Band unsubscribes all default LogSubscribers from Rails Instrumentation API,

--- a/lib/rails_band/deprecation_subscriber.rb
+++ b/lib/rails_band/deprecation_subscriber.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module RailsBand
+  # DeprecationSubscriber is responsible for logging deprecation warnings.
+  class DeprecationSubscriber < ::ActiveSupport::LogSubscriber
+    # DeprecationEvent is a wrapper around a deprecation notification event.
+    class DeprecationEvent < BaseEvent
+      def message
+        @message ||= @event.payload.fetch(:message)
+      end
+
+      def callstack
+        @callstack ||= @event.payload.fetch(:callstack)
+      end
+
+      def gem_name
+        @gem_name ||= @event.payload.fetch(:gem_name)
+      end
+
+      def deprecation_horizon
+        @deprecation_horizon ||= @event.payload.fetch(:deprecation_horizon)
+      end
+    end
+
+    mattr_accessor :consumers
+
+    def deprecation(event)
+      consumer&.call(DeprecationEvent.new(event))
+    end
+
+    private
+
+    def consumer
+      # HACK: ActiveSupport::Subscriber has the instance variable @namespace, but it's not documented.
+      #       This hack might possibly break in the future.
+      namespace = self.class.instance_variable_get(:@namespace)
+      consumers[:"deprecation.#{namespace}"] || consumers[:deprecation] || consumers[:default]
+    end
+  end
+end

--- a/lib/rails_band/railtie.rb
+++ b/lib/rails_band/railtie.rb
@@ -43,6 +43,9 @@ module RailsBand
       RailsBand::ActiveSupport::LogSubscriber.consumers = consumers
       RailsBand::ActiveSupport::LogSubscriber.attach_to :active_support
 
+      RailsBand::DeprecationSubscriber.consumers = consumers
+      RailsBand::DeprecationSubscriber.attach_to :rails
+
       if defined?(::ActiveJob)
         require 'active_job/logging'
 

--- a/test/dummy/app/controllers/users_controller.rb
+++ b/test/dummy/app/controllers/users_controller.rb
@@ -93,6 +93,12 @@ class UsersController < ApplicationController
     redirect_to users_path
   end
 
+  def deprecation
+    ActiveSupport::Deprecation.behavior = :notify
+    ActiveSupport::Deprecation.warn('deprecated!!!')
+    redirect_to users_path
+  end
+
   private
 
   def halt!

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     get :cache
     get :cache2
     get :cache3
+    get :deprecation
   end
 
   resources :yay, only: %i[index show]

--- a/test/rails_band/deprecation_subscriber_test.rb
+++ b/test/rails_band/deprecation_subscriber_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class DeprecationSubscriberTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = nil
+  end
+
+  test 'use the consumer with the exact event name' do # rubocop:disable Minitest/MultipleAssertions
+    RailsBand::DeprecationSubscriber.consumers = {
+      'deprecation.rails': ->(event) { @event = event }
+    }
+    get '/users/1/deprecation'
+    assert_match(/DEPRECATION WARNING: deprecated!!!/, @event.message)
+    assert_equal 'Rails', @event.gem_name
+    assert_instance_of String, @event.deprecation_horizon
+    @event.callstack.each do |location|
+      assert_instance_of Thread::Backtrace::Location, location
+    end
+  end
+
+  test 'use the consumer with namespace' do # rubocop:disable Minitest/MultipleAssertions
+    RailsBand::DeprecationSubscriber.consumers = {
+      deprecation: ->(event) { @event = event }
+    }
+    get '/users/1/deprecation'
+    assert_match(/DEPRECATION WARNING: deprecated!!!/, @event.message)
+    assert_equal 'Rails', @event.gem_name
+    assert_instance_of String, @event.deprecation_horizon
+    @event.callstack.each do |location|
+      assert_instance_of Thread::Backtrace::Location, location
+    end
+  end
+
+  test 'use the consumer with default' do # rubocop:disable Minitest/MultipleAssertions
+    RailsBand::DeprecationSubscriber.consumers = {
+      default: ->(event) { @event = event }
+    }
+    get '/users/1/deprecation'
+    assert_match(/DEPRECATION WARNING: deprecated!!!/, @event.message)
+    assert_equal 'Rails', @event.gem_name
+    assert_instance_of String, @event.deprecation_horizon
+    @event.callstack.each do |location|
+      assert_instance_of Thread::Backtrace::Location, location
+    end
+  end
+
+  test 'do not use the consumer because the event is not for the target' do
+    RailsBand::DeprecationSubscriber.consumers = {
+      'unknown.rails': ->(event) { @event = event }
+    }
+    get '/users/1/deprecation'
+    assert_nil @event
+  end
+end


### PR DESCRIPTION
Support [deprecation.rails](https://guides.rubyonrails.org/active_support_instrumentation.html#deprecation-rails).