### PR TITLE
Remove `#children` fron `BaseEvent`

### DIFF
--- a/lib/rails_band/base_event.rb
+++ b/lib/rails_band/base_event.rb
@@ -3,7 +3,7 @@
 module RailsBand
   # The base class of each Event class.
   class BaseEvent
-    attr_reader :name, :time, :end, :transaction_id, :children,
+    attr_reader :name, :time, :end, :transaction_id,
                 :cpu_time, :idle_time, :allocations, :duration
 
     # @param event [ActiveSupport::Notifications::Event]
@@ -13,7 +13,6 @@ module RailsBand
       @time = event.time
       @end = event.end
       @transaction_id = event.transaction_id
-      @children = event.children
       @cpu_time = event.cpu_time
       @idle_time = event.idle_time
       @allocations = event.allocations
@@ -22,7 +21,7 @@ module RailsBand
 
     def to_h
       @to_h ||= {
-        name: @name, time: @time, end: @end, transaction_id: @transaction_id, children: @children,
+        name: @name, time: @time, end: @end, transaction_id: @transaction_id,
         cpu_time: @cpu_time, idle_time: @idle_time, allocations: @allocations, duration: @duration
       }.merge!(
         public_methods(false).reject { |meth| non_hash_keys.include?(meth) }.each_with_object({}) do |meth, h|

--- a/test/rails_band/action_cable/event/broadcast_test.rb
+++ b/test/rails_band/action_cable/event/broadcast_test.rb
@@ -36,12 +36,6 @@ class BroadcastTest < ::ActionCable::Channel::TestCase
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    subscribe number: '2'
-    perform :hello, { name: 'J' }
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     subscribe number: '2'
     perform :hello, { name: 'J' }
@@ -69,7 +63,7 @@ class BroadcastTest < ::ActionCable::Channel::TestCase
   test 'calls #to_h' do
     subscribe number: '2'
     perform :hello, { name: 'J' }
-    %i[name time end transaction_id children cpu_time idle_time allocations duration broadcasting message
+    %i[name time end transaction_id cpu_time idle_time allocations duration broadcasting message
        coder].each do |key|
       assert_includes @event.to_h, key
     end

--- a/test/rails_band/action_cable/event/perform_action_test.rb
+++ b/test/rails_band/action_cable/event/perform_action_test.rb
@@ -36,12 +36,6 @@ class PerformActionTest < ::ActionCable::Channel::TestCase
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    subscribe number: '2'
-    perform :hello, { name: 'J' }
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     subscribe number: '2'
     perform :hello, { name: 'J' }
@@ -69,7 +63,7 @@ class PerformActionTest < ::ActionCable::Channel::TestCase
   test 'calls #to_h' do
     subscribe number: '2'
     perform :hello, { name: 'J' }
-    %i[name time end transaction_id children cpu_time idle_time allocations duration
+    %i[name time end transaction_id cpu_time idle_time allocations duration
        channel_class action data].each do |key|
       assert_includes @event.to_h, key
     end

--- a/test/rails_band/action_cable/event/transmit_subscription_confirmation_test.rb
+++ b/test/rails_band/action_cable/event/transmit_subscription_confirmation_test.rb
@@ -36,12 +36,6 @@ class TransmitSubscriptionConfirmationTest < ::ActionCable::Channel::TestCase
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    subscribe number: '2'
-    perform :call_transmit, { name: 'J' }
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     subscribe number: '2'
     perform :call_transmit, { name: 'J' }
@@ -69,7 +63,7 @@ class TransmitSubscriptionConfirmationTest < ::ActionCable::Channel::TestCase
   test 'calls #to_h' do
     subscribe number: '2'
     perform :call_transmit, { name: 'J' }
-    %i[name time end transaction_id children cpu_time idle_time allocations duration channel_class].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration channel_class].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/action_cable/event/transmit_subscription_rejection_test.rb
+++ b/test/rails_band/action_cable/event/transmit_subscription_rejection_test.rb
@@ -32,11 +32,6 @@ class TransmitSubscriptionRejectionTest < ::ActionCable::Channel::TestCase
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    subscribe number: '-3'
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     subscribe number: '-3'
     assert_instance_of Float, @event.cpu_time
@@ -59,7 +54,7 @@ class TransmitSubscriptionRejectionTest < ::ActionCable::Channel::TestCase
 
   test 'calls #to_h' do
     subscribe number: '-3'
-    %i[name time end transaction_id children cpu_time idle_time allocations duration channel_class].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration channel_class].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/action_cable/event/transmit_test.rb
+++ b/test/rails_band/action_cable/event/transmit_test.rb
@@ -36,12 +36,6 @@ class TransmitTest < ::ActionCable::Channel::TestCase
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    subscribe number: '2'
-    perform :call_transmit, { name: 'J' }
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     subscribe number: '2'
     perform :call_transmit, { name: 'J' }
@@ -69,8 +63,7 @@ class TransmitTest < ::ActionCable::Channel::TestCase
   test 'calls #to_h' do
     subscribe number: '2'
     perform :call_transmit, { name: 'J' }
-    %i[name time end transaction_id children cpu_time idle_time allocations duration
-       channel_class data via].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration channel_class data via].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/action_controller/event/exist_fragment_test.rb
+++ b/test/rails_band/action_controller/event/exist_fragment_test.rb
@@ -31,11 +31,6 @@ class ExistFragmentTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get '/users'
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get '/users'
     assert_instance_of Float, @event.cpu_time
@@ -58,7 +53,7 @@ class ExistFragmentTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get '/users'
-    %i[name time end transaction_id children cpu_time idle_time allocations duration key].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration key].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/action_controller/event/expire_fragment_test.rb
+++ b/test/rails_band/action_controller/event/expire_fragment_test.rb
@@ -31,11 +31,6 @@ class ExpireFragmentTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get '/users'
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get '/users'
     assert_instance_of Float, @event.cpu_time
@@ -58,7 +53,7 @@ class ExpireFragmentTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get '/users'
-    %i[name time end transaction_id children cpu_time idle_time allocations duration key].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration key].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/action_controller/event/halted_callback_test.rb
+++ b/test/rails_band/action_controller/event/halted_callback_test.rb
@@ -30,11 +30,6 @@ class HaltedCallbackTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get '/users/123/callback'
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get '/users/123/callback'
     assert_instance_of Float, @event.cpu_time
@@ -57,7 +52,7 @@ class HaltedCallbackTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get '/users/123/callback'
-    %i[name time end transaction_id children cpu_time idle_time allocations duration filter].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration filter].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/action_controller/event/process_action_test.rb
+++ b/test/rails_band/action_controller/event/process_action_test.rb
@@ -30,11 +30,6 @@ class ProcessActionTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get '/users'
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get '/users'
     assert_instance_of Float, @event.cpu_time
@@ -57,7 +52,7 @@ class ProcessActionTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get '/users'
-    %i[name time end transaction_id children cpu_time idle_time allocations duration controller action params headers
+    %i[name time end transaction_id cpu_time idle_time allocations duration controller action params headers
        format method path status view_runtime db_runtime].each do |key|
       assert_includes @event.to_h, key
     end

--- a/test/rails_band/action_controller/event/read_fragment_test.rb
+++ b/test/rails_band/action_controller/event/read_fragment_test.rb
@@ -31,11 +31,6 @@ class ReadFragmentTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get '/users'
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get '/users'
     assert_instance_of Float, @event.cpu_time
@@ -58,7 +53,7 @@ class ReadFragmentTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get '/users'
-    %i[name time end transaction_id children cpu_time idle_time allocations duration key].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration key].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/action_controller/event/redirect_to_test.rb
+++ b/test/rails_band/action_controller/event/redirect_to_test.rb
@@ -31,11 +31,6 @@ class RedirectToTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get '/users/123/redirect'
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get '/users/123/redirect'
     assert_instance_of Float, @event.cpu_time
@@ -58,7 +53,7 @@ class RedirectToTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get '/users/123/redirect'
-    %i[name time end transaction_id children cpu_time idle_time allocations duration
+    %i[name time end transaction_id cpu_time idle_time allocations duration
        status location].each do |key|
       assert_includes @event.to_h, key
     end

--- a/test/rails_band/action_controller/event/send_data_test.rb
+++ b/test/rails_band/action_controller/event/send_data_test.rb
@@ -31,11 +31,6 @@ class SendDataTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get '/users/123/data'
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get '/users/123/data'
     assert_instance_of Float, @event.cpu_time
@@ -58,7 +53,7 @@ class SendDataTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get '/users/123/data'
-    %i[name time end transaction_id children cpu_time idle_time allocations duration
+    %i[name time end transaction_id cpu_time idle_time allocations duration
        filename type disposition status].each do |key|
       assert_includes @event.to_h, key
     end

--- a/test/rails_band/action_controller/event/send_file_test.rb
+++ b/test/rails_band/action_controller/event/send_file_test.rb
@@ -31,11 +31,6 @@ class SendFileTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get '/users/123/file'
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get '/users/123/file'
     assert_instance_of Float, @event.cpu_time
@@ -58,7 +53,7 @@ class SendFileTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get '/users/123/file'
-    %i[name time end transaction_id children cpu_time idle_time allocations duration
+    %i[name time end transaction_id cpu_time idle_time allocations duration
        path filename type disposition status].each do |key|
       assert_includes @event.to_h, key
     end

--- a/test/rails_band/action_controller/event/start_processing_test.rb
+++ b/test/rails_band/action_controller/event/start_processing_test.rb
@@ -30,11 +30,6 @@ class StartProcessingTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get '/users'
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get '/users'
     assert_instance_of Float, @event.cpu_time
@@ -57,7 +52,7 @@ class StartProcessingTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get '/users'
-    %i[name time end transaction_id children cpu_time idle_time allocations duration controller action params headers
+    %i[name time end transaction_id cpu_time idle_time allocations duration controller action params headers
        format method path].each do |key|
       assert_includes @event.to_h, key
     end

--- a/test/rails_band/action_controller/event/unpermitted_parameters_test.rb
+++ b/test/rails_band/action_controller/event/unpermitted_parameters_test.rb
@@ -31,11 +31,6 @@ class UnpermittedParametersTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    patch "/users/#{@user.id}", params: { name: 'foo!', nickname: 'F', login_shell: 'zsh' }
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     patch "/users/#{@user.id}", params: { name: 'foo!', nickname: 'F', login_shell: 'zsh' }
     assert_instance_of Float, @event.cpu_time
@@ -58,7 +53,7 @@ class UnpermittedParametersTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     patch "/users/#{@user.id}", params: { name: 'foo!', nickname: 'F', login_shell: 'zsh' }
-    %i[name time end transaction_id children cpu_time idle_time allocations duration keys].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration keys].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/action_controller/event/write_fragment_test.rb
+++ b/test/rails_band/action_controller/event/write_fragment_test.rb
@@ -31,11 +31,6 @@ class WriteFragmentTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get '/users'
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get '/users'
     assert_instance_of Float, @event.cpu_time
@@ -58,7 +53,7 @@ class WriteFragmentTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get '/users'
-    %i[name time end transaction_id children cpu_time idle_time allocations duration key].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration key].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/action_mailer/event/deliver_test.rb
+++ b/test/rails_band/action_mailer/event/deliver_test.rb
@@ -31,11 +31,6 @@ class DeliverTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get "/users/#{@user.id}/welcome_email"
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get "/users/#{@user.id}/welcome_email"
     assert_instance_of Float, @event.cpu_time
@@ -58,7 +53,7 @@ class DeliverTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get "/users/#{@user.id}/welcome_email"
-    %i[name time end transaction_id children cpu_time idle_time allocations duration mailer message_id
+    %i[name time end transaction_id cpu_time idle_time allocations duration mailer message_id
        subject to from bcc cc date mail perform_deliveries].each do |key|
       assert_includes @event.to_h, key
     end

--- a/test/rails_band/action_mailer/event/process_test.rb
+++ b/test/rails_band/action_mailer/event/process_test.rb
@@ -31,11 +31,6 @@ class ProcessTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get "/users/#{@user.id}/welcome_email"
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get "/users/#{@user.id}/welcome_email"
     assert_instance_of Float, @event.cpu_time
@@ -58,7 +53,7 @@ class ProcessTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get "/users/#{@user.id}/welcome_email"
-    %i[name time end transaction_id children cpu_time idle_time allocations duration mailer action args].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration mailer action args].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/action_view/event/render_collection_test.rb
+++ b/test/rails_band/action_view/event/render_collection_test.rb
@@ -32,11 +32,6 @@ class RenderCollectionTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get '/users'
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get '/users'
     assert_instance_of Float, @event.cpu_time
@@ -59,7 +54,7 @@ class RenderCollectionTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get '/users'
-    %i[name time end transaction_id children cpu_time idle_time allocations duration identifier layout count
+    %i[name time end transaction_id cpu_time idle_time allocations duration identifier layout count
        cache_hits].each do |key|
       assert_includes @event.to_h, key
     end

--- a/test/rails_band/action_view/event/render_partial_test.rb
+++ b/test/rails_band/action_view/event/render_partial_test.rb
@@ -31,11 +31,6 @@ class RenderPartialTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get "/users/#{@user.id}"
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get "/users/#{@user.id}"
     assert_instance_of Float, @event.cpu_time
@@ -58,7 +53,7 @@ class RenderPartialTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get "/users/#{@user.id}"
-    %i[name time end transaction_id children cpu_time idle_time allocations duration identifier layout
+    %i[name time end transaction_id cpu_time idle_time allocations duration identifier layout
        cache_hit].each do |key|
       assert_includes @event.to_h, key
     end

--- a/test/rails_band/action_view/event/render_template_test.rb
+++ b/test/rails_band/action_view/event/render_template_test.rb
@@ -31,11 +31,6 @@ class RenderTemplateTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get '/users'
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get '/users'
     assert_instance_of Float, @event.cpu_time
@@ -58,7 +53,7 @@ class RenderTemplateTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get '/users'
-    %i[name time end transaction_id children cpu_time idle_time allocations duration identifier layout].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration identifier layout].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/active_job/event/discard_test.rb
+++ b/test/rails_band/active_job/event/discard_test.rb
@@ -42,14 +42,6 @@ class DiscardTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'returns children' do
-    perform_enqueued_jobs do
-      DiscardJob.perform_later
-    rescue DiscardJob::Error
-      assert_instance_of Array, @event.children
-    end
-  end
-
   test 'returns cpu_time' do
     perform_enqueued_jobs do
       DiscardJob.perform_later
@@ -86,7 +78,7 @@ class DiscardTest < ActionDispatch::IntegrationTest
     perform_enqueued_jobs do
       DiscardJob.perform_later
     rescue DiscardJob::Error
-      %i[name time end transaction_id children cpu_time idle_time allocations duration adapter job error].each do |key|
+      %i[name time end transaction_id cpu_time idle_time allocations duration adapter job error].each do |key|
         assert_includes @event.to_h, key
       end
     end

--- a/test/rails_band/active_job/event/enqueue_at_test.rb
+++ b/test/rails_band/active_job/event/enqueue_at_test.rb
@@ -30,11 +30,6 @@ class EnqueueAtTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get '/yay'
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get '/yay'
     assert_instance_of Float, @event.cpu_time
@@ -57,7 +52,7 @@ class EnqueueAtTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get '/yay'
-    %i[name time end transaction_id children cpu_time idle_time allocations duration adapter job].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration adapter job].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/active_job/event/enqueue_retry_test.rb
+++ b/test/rails_band/active_job/event/enqueue_retry_test.rb
@@ -30,11 +30,6 @@ class EnqueueRetryTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    FlakyJob.perform_now
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     FlakyJob.perform_now
     assert_instance_of Float, @event.cpu_time
@@ -57,7 +52,7 @@ class EnqueueRetryTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     FlakyJob.perform_now
-    %i[name time end transaction_id children cpu_time idle_time allocations duration adapter job
+    %i[name time end transaction_id cpu_time idle_time allocations duration adapter job
        wait error].each do |key|
       assert_includes @event.to_h, key
     end

--- a/test/rails_band/active_job/event/enqueue_test.rb
+++ b/test/rails_band/active_job/event/enqueue_test.rb
@@ -30,11 +30,6 @@ class EnqueueTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get '/yay/123'
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get '/yay/123'
     assert_instance_of Float, @event.cpu_time
@@ -57,7 +52,7 @@ class EnqueueTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get '/yay/123'
-    %i[name time end transaction_id children cpu_time idle_time allocations duration adapter job].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration adapter job].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/active_job/event/perform_start_test.rb
+++ b/test/rails_band/active_job/event/perform_start_test.rb
@@ -30,11 +30,6 @@ class PerformStartTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    YayJob.perform_now(name: 'JJ', message: 'Hi')
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     YayJob.perform_now(name: 'JJ', message: 'Hi')
     assert_instance_of Float, @event.cpu_time
@@ -57,7 +52,7 @@ class PerformStartTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     YayJob.perform_now(name: 'JJ', message: 'Hi')
-    %i[name time end transaction_id children cpu_time idle_time allocations duration adapter job].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration adapter job].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/active_job/event/perform_test.rb
+++ b/test/rails_band/active_job/event/perform_test.rb
@@ -30,11 +30,6 @@ class PerformTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    YayJob.perform_now(name: 'JJ', message: 'Hi')
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     YayJob.perform_now(name: 'JJ', message: 'Hi')
     assert_instance_of Float, @event.cpu_time
@@ -57,7 +52,7 @@ class PerformTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     YayJob.perform_now(name: 'JJ', message: 'Hi')
-    %i[name time end transaction_id children cpu_time idle_time allocations duration adapter job].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration adapter job].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/active_job/event/retry_stopped_test.rb
+++ b/test/rails_band/active_job/event/retry_stopped_test.rb
@@ -42,14 +42,6 @@ class RetryStoppedTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'returns children' do
-    perform_enqueued_jobs do
-      FlakyJob.perform_later
-    rescue FlakyJob::Error
-      assert_instance_of Array, @event.children
-    end
-  end
-
   test 'returns cpu_time' do
     perform_enqueued_jobs do
       FlakyJob.perform_later
@@ -86,7 +78,7 @@ class RetryStoppedTest < ActionDispatch::IntegrationTest
     perform_enqueued_jobs do
       FlakyJob.perform_later
     rescue FlakyJob::Error
-      %i[name time end transaction_id children cpu_time idle_time allocations duration adapter job error].each do |key|
+      %i[name time end transaction_id cpu_time idle_time allocations duration adapter job error].each do |key|
         assert_includes @event.to_h, key
       end
     end

--- a/test/rails_band/active_record/event/instantiation_test.rb
+++ b/test/rails_band/active_record/event/instantiation_test.rb
@@ -31,11 +31,6 @@ class InstantiationTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get "/users/#{@user.id}"
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get "/users/#{@user.id}"
     assert_instance_of Float, @event.cpu_time
@@ -58,7 +53,7 @@ class InstantiationTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get "/users/#{@user.id}"
-    %i[name time end transaction_id children cpu_time idle_time allocations duration record_count
+    %i[name time end transaction_id cpu_time idle_time allocations duration record_count
        class_name].each do |key|
       assert_includes @event.to_h, key
     end

--- a/test/rails_band/active_record/event/sql_test.rb
+++ b/test/rails_band/active_record/event/sql_test.rb
@@ -31,11 +31,6 @@ class SqlTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get "/users/#{@user.id}"
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get "/users/#{@user.id}"
     assert_instance_of Float, @event.cpu_time
@@ -58,7 +53,7 @@ class SqlTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get "/users/#{@user.id}"
-    %i[name time end transaction_id children cpu_time idle_time allocations duration sql sql_name binds
+    %i[name time end transaction_id cpu_time idle_time allocations duration sql sql_name binds
        type_casted_binds connection statement_name async cached].each do |key|
       assert_includes @event.to_h, key
     end

--- a/test/rails_band/active_record/event/strict_loading_violation_test.rb
+++ b/test/rails_band/active_record/event/strict_loading_violation_test.rb
@@ -45,11 +45,6 @@ if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1')
       assert_instance_of String, @event.transaction_id
     end
 
-    test 'returns children' do
-      get "/users/#{@user.id}/notes"
-      assert_instance_of Array, @event.children
-    end
-
     test 'returns cpu_time' do
       get "/users/#{@user.id}/notes"
       assert_instance_of Float, @event.cpu_time
@@ -72,7 +67,7 @@ if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1')
 
     test 'calls #to_h' do
       get "/users/#{@user.id}/notes"
-      %i[name time end transaction_id children cpu_time idle_time allocations duration owner
+      %i[name time end transaction_id cpu_time idle_time allocations duration owner
          reflection].each do |key|
         assert_includes @event.to_h, key
       end

--- a/test/rails_band/active_storage/event/analyze_test.rb
+++ b/test/rails_band/active_storage/event/analyze_test.rb
@@ -31,11 +31,6 @@ if Gem::Version.new(Rails.version) >= Gem::Version.new('7.0')
       assert_instance_of String, @event.transaction_id
     end
 
-    test 'returns children' do
-      post '/teams/analyze', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
-      assert_instance_of Array, @event.children
-    end
-
     test 'returns cpu_time' do
       post '/teams/analyze', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
       assert_instance_of Float, @event.cpu_time
@@ -58,7 +53,7 @@ if Gem::Version.new(Rails.version) >= Gem::Version.new('7.0')
 
     test 'calls #to_h' do
       post '/teams/analyze', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
-      %i[name time end transaction_id children cpu_time idle_time allocations duration analyzer].each do |key|
+      %i[name time end transaction_id cpu_time idle_time allocations duration analyzer].each do |key|
         assert_includes @event.to_h, key
       end
     end

--- a/test/rails_band/active_storage/event/preview_test.rb
+++ b/test/rails_band/active_storage/event/preview_test.rb
@@ -30,11 +30,6 @@ class PreviewTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    post '/teams/preview', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     post '/teams/preview', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
     assert_instance_of Float, @event.cpu_time
@@ -57,7 +52,7 @@ class PreviewTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     post '/teams/preview', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
-    %i[name time end transaction_id children cpu_time idle_time allocations duration key].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration key].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/active_storage/event/service_delete_prefixed_test.rb
+++ b/test/rails_band/active_storage/event/service_delete_prefixed_test.rb
@@ -30,11 +30,6 @@ class ServiceDeletePrefixedTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
     assert_instance_of Float, @event.cpu_time
@@ -57,7 +52,7 @@ class ServiceDeletePrefixedTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
-    %i[name time end transaction_id children cpu_time idle_time allocations duration prefix service].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration prefix service].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/active_storage/event/service_delete_test.rb
+++ b/test/rails_band/active_storage/event/service_delete_test.rb
@@ -30,11 +30,6 @@ class ServiceDeleteTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
     assert_instance_of Float, @event.cpu_time
@@ -57,7 +52,7 @@ class ServiceDeleteTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
-    %i[name time end transaction_id children cpu_time idle_time allocations duration key service].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration key service].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/active_storage/event/service_download_chunk_test.rb
+++ b/test/rails_band/active_storage/event/service_download_chunk_test.rb
@@ -30,11 +30,6 @@ class ServiceDownloadChunkTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
     assert_instance_of Float, @event.cpu_time
@@ -57,7 +52,7 @@ class ServiceDownloadChunkTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
-    %i[name time end transaction_id children cpu_time idle_time allocations duration key service range].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration key service range].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/active_storage/event/service_download_test.rb
+++ b/test/rails_band/active_storage/event/service_download_test.rb
@@ -30,11 +30,6 @@ class ServiceDownloadTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
     assert_instance_of Float, @event.cpu_time
@@ -57,7 +52,7 @@ class ServiceDownloadTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
-    %i[name time end transaction_id children cpu_time idle_time allocations duration key service].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration key service].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/active_storage/event/service_exist_test.rb
+++ b/test/rails_band/active_storage/event/service_exist_test.rb
@@ -30,11 +30,6 @@ class ServiceExistTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
     assert_instance_of Float, @event.cpu_time
@@ -57,7 +52,7 @@ class ServiceExistTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
-    %i[name time end transaction_id children cpu_time idle_time allocations duration key service exist].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration key service exist].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/active_storage/event/service_streaming_download_test.rb
+++ b/test/rails_band/active_storage/event/service_streaming_download_test.rb
@@ -30,11 +30,6 @@ class ServiceStreamingDownloadTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
     assert_instance_of Float, @event.cpu_time
@@ -57,7 +52,7 @@ class ServiceStreamingDownloadTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
-    %i[name time end transaction_id children cpu_time idle_time allocations duration key service].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration key service].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/active_storage/event/service_update_metadata_test.rb
+++ b/test/rails_band/active_storage/event/service_update_metadata_test.rb
@@ -30,11 +30,6 @@ class ServiceUpdateMetadataTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
     assert_instance_of Float, @event.cpu_time
@@ -57,7 +52,7 @@ class ServiceUpdateMetadataTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
-    %i[name time end transaction_id children cpu_time idle_time allocations duration key service
+    %i[name time end transaction_id cpu_time idle_time allocations duration key service
        content_type disposition].each do |key|
       assert_includes @event.to_h, key
     end

--- a/test/rails_band/active_storage/event/service_upload_test.rb
+++ b/test/rails_band/active_storage/event/service_upload_test.rb
@@ -30,11 +30,6 @@ class ServiceUploadTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
     assert_instance_of Float, @event.cpu_time
@@ -57,7 +52,7 @@ class ServiceUploadTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
-    %i[name time end transaction_id children cpu_time idle_time allocations duration key checksum service].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration key checksum service].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/active_storage/event/service_url_test.rb
+++ b/test/rails_band/active_storage/event/service_url_test.rb
@@ -30,11 +30,6 @@ class ServiceUrlTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
     assert_instance_of Float, @event.cpu_time
@@ -57,7 +52,7 @@ class ServiceUrlTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     post '/teams', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
-    %i[name time end transaction_id children cpu_time idle_time allocations duration key service url].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration key service url].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/active_storage/event/transform_test.rb
+++ b/test/rails_band/active_storage/event/transform_test.rb
@@ -30,11 +30,6 @@ class TransformTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    post '/teams/transform', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     post '/teams/transform', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
     assert_instance_of Float, @event.cpu_time
@@ -57,7 +52,7 @@ class TransformTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     post '/teams/transform', params: { team: { name: 'A', avatar: fixture_file_upload('test.png') } }
-    %i[name time end transaction_id children cpu_time idle_time allocations duration].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/active_support/event/cache_delete_multi_test.rb
+++ b/test/rails_band/active_support/event/cache_delete_multi_test.rb
@@ -31,11 +31,6 @@ if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1')
       assert_instance_of String, @event.transaction_id
     end
 
-    test 'returns children' do
-      get '/users/123/cache3'
-      assert_instance_of Array, @event.children
-    end
-
     test 'returns cpu_time' do
       get '/users/123/cache3'
       assert_instance_of Float, @event.cpu_time
@@ -58,7 +53,7 @@ if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1')
 
     test 'calls #to_h' do
       get '/users/123/cache3'
-      %i[name time end transaction_id children cpu_time idle_time allocations duration key].each do |key|
+      %i[name time end transaction_id cpu_time idle_time allocations duration key].each do |key|
         assert_includes @event.to_h, key
       end
     end

--- a/test/rails_band/active_support/event/cache_delete_test.rb
+++ b/test/rails_band/active_support/event/cache_delete_test.rb
@@ -30,11 +30,6 @@ class CacheDeleteTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get '/users/123/cache2'
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get '/users/123/cache2'
     assert_instance_of Float, @event.cpu_time
@@ -57,7 +52,7 @@ class CacheDeleteTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get '/users/123/cache2'
-    %i[name time end transaction_id children cpu_time idle_time allocations duration key].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration key].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/active_support/event/cache_exist_test.rb
+++ b/test/rails_band/active_support/event/cache_exist_test.rb
@@ -30,11 +30,6 @@ class CacheExistTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get '/users/123/cache2'
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get '/users/123/cache2'
     assert_instance_of Float, @event.cpu_time
@@ -57,7 +52,7 @@ class CacheExistTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get '/users/123/cache2'
-    %i[name time end transaction_id children cpu_time idle_time allocations duration key].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration key].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/active_support/event/cache_fetch_hit_test.rb
+++ b/test/rails_band/active_support/event/cache_fetch_hit_test.rb
@@ -30,11 +30,6 @@ class CacheFetchHitTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get '/users/123/cache2'
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get '/users/123/cache2'
     assert_instance_of Float, @event.cpu_time
@@ -57,7 +52,7 @@ class CacheFetchHitTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get '/users/123/cache2'
-    %i[name time end transaction_id children cpu_time idle_time allocations duration key].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration key].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/active_support/event/cache_generate_test.rb
+++ b/test/rails_band/active_support/event/cache_generate_test.rb
@@ -31,11 +31,6 @@ class CacheGenerateTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get "/users/#{@user.id}/cache"
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get "/users/#{@user.id}/cache"
     assert_instance_of Float, @event.cpu_time
@@ -58,7 +53,7 @@ class CacheGenerateTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get "/users/#{@user.id}/cache"
-    %i[name time end transaction_id children cpu_time idle_time allocations duration key].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration key].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/active_support/event/cache_read_multi_test.rb
+++ b/test/rails_band/active_support/event/cache_read_multi_test.rb
@@ -30,11 +30,6 @@ class CacheReadMultiTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get '/users/123/cache2'
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get '/users/123/cache2'
     assert_instance_of Float, @event.cpu_time
@@ -57,8 +52,7 @@ class CacheReadMultiTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get '/users/123/cache2'
-    %i[name time end transaction_id children cpu_time idle_time allocations duration key hits
-       super_operation].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration key hits super_operation].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/active_support/event/cache_read_test.rb
+++ b/test/rails_band/active_support/event/cache_read_test.rb
@@ -31,11 +31,6 @@ class CacheReadTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get "/users/#{@user.id}/cache"
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get "/users/#{@user.id}/cache"
     assert_instance_of Float, @event.cpu_time
@@ -58,8 +53,7 @@ class CacheReadTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get "/users/#{@user.id}/cache"
-    %i[name time end transaction_id children cpu_time idle_time allocations duration key hit
-       super_operation].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration key hit super_operation].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/active_support/event/cache_write_multi_test.rb
+++ b/test/rails_band/active_support/event/cache_write_multi_test.rb
@@ -30,11 +30,6 @@ class CacheWriteMultiTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get '/users/123/cache3'
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get '/users/123/cache3'
     assert_instance_of Float, @event.cpu_time
@@ -57,7 +52,7 @@ class CacheWriteMultiTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get '/users/123/cache3'
-    %i[name time end transaction_id children cpu_time idle_time allocations duration key].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration key].each do |key|
       assert_includes @event.to_h, key
     end
   end

--- a/test/rails_band/active_support/event/cache_write_test.rb
+++ b/test/rails_band/active_support/event/cache_write_test.rb
@@ -30,11 +30,6 @@ class CacheWriteTest < ActionDispatch::IntegrationTest
     assert_instance_of String, @event.transaction_id
   end
 
-  test 'returns children' do
-    get '/users/123/cache2'
-    assert_instance_of Array, @event.children
-  end
-
   test 'returns cpu_time' do
     get '/users/123/cache2'
     assert_instance_of Float, @event.cpu_time
@@ -57,7 +52,7 @@ class CacheWriteTest < ActionDispatch::IntegrationTest
 
   test 'calls #to_h' do
     get '/users/123/cache2'
-    %i[name time end transaction_id children cpu_time idle_time allocations duration key].each do |key|
+    %i[name time end transaction_id cpu_time idle_time allocations duration key].each do |key|
       assert_includes @event.to_h, key
     end
   end


### PR DESCRIPTION
`#children` has been deprecated as of Rails 7.2.

https://github.com/rails/rails/pull/43390

Unlike Rails, I decided to remove `#children` from `BaseEvent`
since it'd be a techdebt to keep this method in the future,
and I guess this method would not be used very well.

By the way, I found this deprecation on Rails when I'm about to
add the support for `deprecation.rails` on #89. I hope this won't cause
problems for users who use this gem.