### PR TITLE
Add #abort in ActiveJob instrumentations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 /tmp/
 /test/dummy/db/*.sqlite3
 /test/dummy/db/*.sqlite3-*
-/test/dummy/log/*.log
+/test/dummy/log/*.log*
 /test/dummy/storage/
 /test/dummy/tmp/
 Gemfile.lock

--- a/lib/rails_band/active_job/event/enqueue.rb
+++ b/lib/rails_band/active_job/event/enqueue.rb
@@ -12,6 +12,14 @@ module RailsBand
         def job
           @job ||= @event.payload.fetch(:job)
         end
+
+        if Gem::Version.new(Rails.version) > Gem::Version.new('7.0')
+          define_method(:aborted) do
+            return @aborted if defined?(@aborted)
+
+            @aborted = @event.payload[:aborted]
+          end
+        end
       end
     end
   end

--- a/lib/rails_band/active_job/event/enqueue_at.rb
+++ b/lib/rails_band/active_job/event/enqueue_at.rb
@@ -12,6 +12,14 @@ module RailsBand
         def job
           @job ||= @event.payload.fetch(:job)
         end
+
+        if Gem::Version.new(Rails.version) > Gem::Version.new('7.0')
+          define_method(:aborted) do
+            return @aborted if defined?(@aborted)
+
+            @aborted = @event.payload[:aborted]
+          end
+        end
       end
     end
   end

--- a/lib/rails_band/active_job/event/perform.rb
+++ b/lib/rails_band/active_job/event/perform.rb
@@ -12,6 +12,14 @@ module RailsBand
         def job
           @job ||= @event.payload.fetch(:job)
         end
+
+        if Gem::Version.new(Rails.version) > Gem::Version.new('7.0')
+          define_method(:aborted) do
+            return @aborted if defined?(@aborted)
+
+            @aborted = @event.payload[:aborted]
+          end
+        end
       end
     end
   end

--- a/test/dummy/app/controllers/yay_controller.rb
+++ b/test/dummy/app/controllers/yay_controller.rb
@@ -2,12 +2,14 @@
 
 class YayController < ApplicationController
   def index
-    YayJob.set(wait: 30.seconds).perform_later(name: 'foo', message: 'Hi')
+    aborted = ActiveModel::Type::Boolean.new.cast(params[:aborted])
+    YayJob.set(wait: 30.seconds).perform_later(name: 'foo', message: 'Hi', **{ aborted: aborted }.compact)
     head :no_content
   end
 
   def show
-    YayJob.perform_later(name: 'E!', message: 'This is E.')
+    aborted = ActiveModel::Type::Boolean.new.cast(params[:aborted])
+    YayJob.perform_later(name: 'E!', message: 'This is E.', **{ aborted: aborted }.compact)
     head :no_content
   end
 end

--- a/test/dummy/app/jobs/yay_job.rb
+++ b/test/dummy/app/jobs/yay_job.rb
@@ -3,7 +3,16 @@
 class YayJob < ApplicationJob
   queue_as :default
 
-  def perform(name:, message:)
-    logger.info([name, message].to_json)
+  before_perform :check_abort
+  before_enqueue :check_abort
+
+  def perform(name:, message:, aborted: false)
+    logger.info([name, message, aborted].to_json)
+  end
+
+  private
+
+  def check_abort
+    throw(:abort) if arguments.first[:aborted]
   end
 end

--- a/test/rails_band/active_job/event/enqueue_at_test.rb
+++ b/test/rails_band/active_job/event/enqueue_at_test.rb
@@ -77,4 +77,11 @@ class EnqueueAtTest < ActionDispatch::IntegrationTest
     assert_instance_of YayJob, @event.job
     assert_equal [{ name: 'foo', message: 'Hi' }], @event.job.arguments
   end
+
+  if Gem::Version.new(Rails.version) > Gem::Version.new('7.0')
+    test 'returns aborted' do
+      get '/yay?aborted=true'
+      assert @event.aborted
+    end
+  end
 end

--- a/test/rails_band/active_job/event/enqueue_test.rb
+++ b/test/rails_band/active_job/event/enqueue_test.rb
@@ -77,4 +77,11 @@ class EnqueueTest < ActionDispatch::IntegrationTest
     assert_instance_of YayJob, @event.job
     assert_equal [{ name: 'E!', message: 'This is E.' }], @event.job.arguments
   end
+
+  if Gem::Version.new(Rails.version) > Gem::Version.new('7.0')
+    test 'returns aborted' do
+      get '/yay/123?aborted=true'
+      assert @event.aborted
+    end
+  end
 end

--- a/test/rails_band/active_job/event/perform_test.rb
+++ b/test/rails_band/active_job/event/perform_test.rb
@@ -77,4 +77,11 @@ class PerformTest < ActionDispatch::IntegrationTest
     assert_instance_of YayJob, @event.job
     assert_equal [{ name: 'JJ', message: 'Hi' }], @event.job.arguments
   end
+
+  if Gem::Version.new(Rails.version) > Gem::Version.new('7.0')
+    test 'returns aborted' do
+      YayJob.perform_now(name: 'JJ', message: 'Hi', aborted: true)
+      assert @event.aborted
+    end
+  end
 end


### PR DESCRIPTION
`abort` was introduced in https://github.com/rails/rails/pull/37830

It might be helpful to support this new event. So, I added it in
`enqueue`, `enqueue_at`, and `perform` in `active_job`.