### PR TITLE
Support process_middleware.action_dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 
 | Event name                                                                                                                                    | Supported |
 | --------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
-| [`process_middleware.action_dispatch`](https://guides.rubyonrails.org/active_support_instrumentation.html#process-middleware-action-dispatch) |           |
+| [`process_middleware.action_dispatch`](https://guides.rubyonrails.org/active_support_instrumentation.html#process-middleware-action-dispatch) | ✅        |
 
 ### Action View
 

--- a/lib/rails_band.rb
+++ b/lib/rails_band.rb
@@ -25,6 +25,10 @@ module RailsBand
     autoload :LogSubscriber, 'rails_band/action_mailer/log_subscriber'
   end
 
+  module ActionDispatch
+    autoload :LogSubscriber, 'rails_band/action_dispatch/log_subscriber'
+  end
+
   module ActiveSupport
     autoload :LogSubscriber, 'rails_band/active_support/log_subscriber'
   end

--- a/lib/rails_band/action_dispatch/event/process_middleware.rb
+++ b/lib/rails_band/action_dispatch/event/process_middleware.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActionDispatch
+    module Event
+      # A wrapper for the event that is passed to `process_middleware.action_dispatch`.
+      class ProcessMiddleware < BaseEvent
+        def middleware
+          @middleware ||= @event.payload.fetch(:middleware)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/action_dispatch/log_subscriber.rb
+++ b/lib/rails_band/action_dispatch/log_subscriber.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_band/action_dispatch/event/process_middleware'
+
+module RailsBand
+  module ActionDispatch
+    # The custom LogSubscriber for ActionDispatch.
+    class LogSubscriber < ::ActiveSupport::LogSubscriber
+      mattr_accessor :consumers
+
+      def process_middleware(event)
+        consumer_of(__method__)&.call(Event::ProcessMiddleware.new(event))
+      end
+
+      private
+
+      def consumer_of(sub_event)
+        consumers[:"#{sub_event}.action_dispatch"] || consumers[:action_dispatch] || consumers[:default]
+      end
+    end
+  end
+end

--- a/lib/rails_band/railtie.rb
+++ b/lib/rails_band/railtie.rb
@@ -8,6 +8,13 @@ module RailsBand
   class Railtie < ::Rails::Railtie
     config.rails_band = Configuration.new
 
+    config.before_initialize do
+      # NOTE: `ActionDispatch::MiddlewareStack::InstrumentationProxy` will be called
+      #       only when `ActionDispatch::MiddlewareStack#build` detects `process_middleware.action_dispatch`
+      #       is listened to. So, `attach_to` must be called before Rack middlewares will be loaded.
+      RailsBand::ActionDispatch::LogSubscriber.attach_to :action_dispatch
+    end
+
     config.after_initialize do |app|
       consumers = app.config.rails_band.consumers
 
@@ -39,6 +46,8 @@ module RailsBand
         RailsBand::ActiveStorage::LogSubscriber.consumers = consumers
         RailsBand::ActiveStorage::LogSubscriber.attach_to :active_storage
       end
+
+      RailsBand::ActionDispatch::LogSubscriber.consumers = consumers
 
       RailsBand::ActiveSupport::LogSubscriber.consumers = consumers
       RailsBand::ActiveSupport::LogSubscriber.attach_to :active_support

--- a/test/rails_band/action_dispatch/event/process_middleware_test.rb
+++ b/test/rails_band/action_dispatch/event/process_middleware_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ProcessMiddlewareTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = nil
+    RailsBand::ActionDispatch::LogSubscriber.consumers = {
+      'process_middleware.action_dispatch': ->(event) { @event = event }
+    }
+    User.create!(name: 'foo', email: 'foo@example.com')
+  end
+
+  test 'returns name' do
+    get '/users'
+    assert_equal 'process_middleware.action_dispatch', @event.name
+  end
+
+  test 'returns time' do
+    get '/users'
+    assert_instance_of Float, @event.time
+  end
+
+  test 'returns end' do
+    get '/users'
+    assert_instance_of Float, @event.end
+  end
+
+  test 'returns transaction_id' do
+    get '/users'
+    assert_instance_of String, @event.transaction_id
+  end
+
+  test 'returns cpu_time' do
+    get '/users'
+    assert_instance_of Float, @event.cpu_time
+  end
+
+  test 'returns idle_time' do
+    get '/users'
+    assert_instance_of Float, @event.idle_time
+  end
+
+  test 'returns allocations' do
+    get '/users'
+    assert_instance_of Integer, @event.allocations
+  end
+
+  test 'returns duration' do
+    get '/users'
+    assert_instance_of Float, @event.duration
+  end
+
+  test 'calls #to_h' do
+    get '/users'
+    %i[name time end transaction_id cpu_time idle_time allocations duration middleware].each do |key|
+      assert_includes @event.to_h, key
+    end
+  end
+
+  test 'calls #slice' do
+    get '/users'
+    assert_equal({ name: 'process_middleware.action_dispatch' }, @event.slice(:name))
+  end
+
+  test 'returns an instance of ProcessMiddleware' do
+    get '/users'
+    assert_instance_of RailsBand::ActionDispatch::Event::ProcessMiddleware, @event
+  end
+
+  test 'returns the middleware' do
+    get '/users'
+    assert_respond_to @event, :middleware
+  end
+end

--- a/test/rails_band/action_dispatch/log_subscriber_test.rb
+++ b/test/rails_band/action_dispatch/log_subscriber_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ActionDispatchLogSubscriberTest < ActionDispatch::IntegrationTest
+  setup do
+    @mock = Minitest::Mock.new
+    @mock.expect(:recv, nil)
+  end
+
+  test 'use the consumer with the exact event name' do
+    RailsBand::ActionDispatch::LogSubscriber.consumers = {
+      'process_middleware.action_dispatch': ->(_event) { @mock.recv }
+    }
+    get '/users'
+    assert_mock @mock
+  end
+
+  test 'use the consumer with namespace' do
+    RailsBand::ActionDispatch::LogSubscriber.consumers = {
+      action_dispatch: ->(event) { @mock.recv if event.name == 'process_middleware.action_dispatch' }
+    }
+    get '/users'
+    assert_mock @mock
+  end
+
+  test 'use the consumer with default' do
+    RailsBand::ActionDispatch::LogSubscriber.consumers = {
+      default: ->(event) { @mock.recv if event.name == 'process_middleware.action_dispatch' }
+    }
+    get '/users'
+    assert_mock @mock
+  end
+
+  test 'do not use the consumer because the event is not for the target' do
+    RailsBand::ActionDispatch::LogSubscriber.consumers = {
+      'unknown.action_dispatch': ->(_event) { @mock.recv }
+    }
+    get '/users'
+    assert_raises MockExpectationError do
+      @mock.verify
+    end
+  end
+end


### PR DESCRIPTION
Support [process_middleware.action_dispatch](https://guides.rubyonrails.org/active_support_instrumentation.html#process-middleware-action-dispatch)