### PR TITLE
Support redirect.action_dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 | Event name                                                                                                                                    | Supported |
 | --------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
 | [`process_middleware.action_dispatch`](https://guides.rubyonrails.org/active_support_instrumentation.html#process-middleware-action-dispatch) | ✅        |
+| [`redirect.action_dispatch`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#redirect-action-dispatch)                 | ✅        |
 
 ### Action View
 

--- a/lib/rails_band/action_dispatch/event/redirect.rb
+++ b/lib/rails_band/action_dispatch/event/redirect.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActionDispatch
+    module Event
+      # A wrapper for the event that is passed to `redirect.action_dispatch`.
+      class Redirect < BaseEvent
+        def status
+          @status ||= @event.payload.fetch(:status)
+        end
+
+        def location
+          @location ||= @event.payload.fetch(:location)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/action_dispatch/log_subscriber.rb
+++ b/lib/rails_band/action_dispatch/log_subscriber.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_band/action_dispatch/event/process_middleware'
+require 'rails_band/action_dispatch/event/redirect'
 
 module RailsBand
   module ActionDispatch
@@ -10,6 +11,10 @@ module RailsBand
 
       def process_middleware(event)
         consumer_of(__method__)&.call(Event::ProcessMiddleware.new(event))
+      end
+
+      def redirect(event)
+        consumer_of(__method__)&.call(Event::Redirect.new(event))
       end
 
       private

--- a/lib/rails_band/railtie.rb
+++ b/lib/rails_band/railtie.rb
@@ -12,6 +12,7 @@ module RailsBand
       # NOTE: `ActionDispatch::MiddlewareStack::InstrumentationProxy` will be called
       #       only when `ActionDispatch::MiddlewareStack#build` detects `process_middleware.action_dispatch`
       #       is listened to. So, `attach_to` must be called before Rack middlewares will be loaded.
+      ::ActionDispatch::LogSubscriber.detach_from :action_dispatch if defined?(::ActionDispatch::LogSubscriber)
       RailsBand::ActionDispatch::LogSubscriber.attach_to :action_dispatch
     end
 

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -21,4 +21,6 @@ Rails.application.routes.draw do
   post '/teams/preview', to: 'teams#preview'
   post '/teams/analyze', to: 'teams#analyze'
   post '/teams/transform', to: 'teams#transform'
+
+  get 'old_users', to: redirect('/users')
 end

--- a/test/rails_band/action_dispatch/event/redirect_test.rb
+++ b/test/rails_band/action_dispatch/event/redirect_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-if Gem::Version.new(Rails.version) > Gem::Version.new('7.0')
+if Gem::Version.new(Rails.version) >= Gem::Version.new('7.1')
   class RedirectTest < ActionDispatch::IntegrationTest
     setup do
       @event = nil

--- a/test/rails_band/action_dispatch/event/redirect_test.rb
+++ b/test/rails_band/action_dispatch/event/redirect_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+if Gem::Version.new(Rails.version) > Gem::Version.new('7.0')
+  class RedirectTest < ActionDispatch::IntegrationTest
+    setup do
+      @event = nil
+      RailsBand::ActionDispatch::LogSubscriber.consumers = {
+        'redirect.action_dispatch': ->(event) { @event = event }
+      }
+    end
+
+    test 'returns name' do
+      get '/old_users'
+      assert_equal 'redirect.action_dispatch', @event.name
+    end
+
+    test 'returns time' do
+      get '/old_users'
+      assert_instance_of Float, @event.time
+    end
+
+    test 'returns end' do
+      get '/old_users'
+      assert_instance_of Float, @event.end
+    end
+
+    test 'returns transaction_id' do
+      get '/old_users'
+      assert_instance_of String, @event.transaction_id
+    end
+
+    test 'returns cpu_time' do
+      get '/old_users'
+      assert_instance_of Float, @event.cpu_time
+    end
+
+    test 'returns idle_time' do
+      get '/old_users'
+      assert_instance_of Float, @event.idle_time
+    end
+
+    test 'returns allocations' do
+      get '/old_users'
+      assert_instance_of Integer, @event.allocations
+    end
+
+    test 'returns duration' do
+      get '/old_users'
+      assert_instance_of Float, @event.duration
+    end
+
+    test 'calls #to_h' do
+      get '/old_users'
+      %i[name time end transaction_id cpu_time idle_time allocations duration status location].each do |key|
+        assert_includes @event.to_h, key
+      end
+    end
+
+    test 'calls #slice' do
+      get '/old_users'
+      assert_equal({ name: 'redirect.action_dispatch' }, @event.slice(:name))
+    end
+
+    test 'returns an instance of Redirect' do
+      get '/old_users'
+      assert_instance_of RailsBand::ActionDispatch::Event::Redirect, @event
+    end
+
+    test 'returns the status' do
+      get '/old_users'
+      assert_equal 301, @event.status
+    end
+
+    test 'returns the location' do
+      get '/old_users'
+      assert_equal 'http://www.example.com/users', @event.location
+    end
+  end
+end

--- a/test/rails_band/action_dispatch/event/redirect_test.rb
+++ b/test/rails_band/action_dispatch/event/redirect_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-if Gem::Version.new(Rails.version) >= Gem::Version.new('7.1')
+if Gem::Version.new(Rails.version) >= Gem::Version.new('7.1.0.alpha')
   class RedirectTest < ActionDispatch::IntegrationTest
     setup do
       @event = nil


### PR DESCRIPTION
Close #100 

Support [redirect.action_dispatch](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#redirect-action-dispatch). Also, unsubscribe the new `ActionDispatch::LogSubscriber`. 