### PR TITLE
Add `:db_runtime` to `perform.active_job`

### DIFF
--- a/lib/rails_band/active_job/event/enqueue.rb
+++ b/lib/rails_band/active_job/event/enqueue.rb
@@ -13,7 +13,7 @@ module RailsBand
           @job ||= @event.payload.fetch(:job)
         end
 
-        if Gem::Version.new(Rails.version) > Gem::Version.new('7.0')
+        if Gem::Version.new(Rails.version) >= Gem::Version.new('7.1.0.alpha')
           define_method(:aborted) do
             return @aborted if defined?(@aborted)
 

--- a/lib/rails_band/active_job/event/enqueue_at.rb
+++ b/lib/rails_band/active_job/event/enqueue_at.rb
@@ -13,7 +13,7 @@ module RailsBand
           @job ||= @event.payload.fetch(:job)
         end
 
-        if Gem::Version.new(Rails.version) > Gem::Version.new('7.0')
+        if Gem::Version.new(Rails.version) >= Gem::Version.new('7.1.0.alpha')
           define_method(:aborted) do
             return @aborted if defined?(@aborted)
 

--- a/lib/rails_band/active_job/event/perform.rb
+++ b/lib/rails_band/active_job/event/perform.rb
@@ -13,11 +13,15 @@ module RailsBand
           @job ||= @event.payload.fetch(:job)
         end
 
-        if Gem::Version.new(Rails.version) > Gem::Version.new('7.0')
+        if Gem::Version.new(Rails.version) >= Gem::Version.new('7.1.0.alpha')
           define_method(:aborted) do
             return @aborted if defined?(@aborted)
 
             @aborted = @event.payload[:aborted]
+          end
+
+          define_method(:db_runtime) do
+            @db_runtime ||= @event.payload[:db_runtime]
           end
         end
       end

--- a/test/rails_band/active_job/event/enqueue_at_test.rb
+++ b/test/rails_band/active_job/event/enqueue_at_test.rb
@@ -78,7 +78,7 @@ class EnqueueAtTest < ActionDispatch::IntegrationTest
     assert_equal [{ name: 'foo', message: 'Hi' }], @event.job.arguments
   end
 
-  if Gem::Version.new(Rails.version) > Gem::Version.new('7.0')
+  if Gem::Version.new(Rails.version) >= Gem::Version.new('7.1.0.alpha')
     test 'returns aborted' do
       get '/yay?aborted=true'
       assert @event.aborted

--- a/test/rails_band/active_job/event/enqueue_test.rb
+++ b/test/rails_band/active_job/event/enqueue_test.rb
@@ -78,7 +78,7 @@ class EnqueueTest < ActionDispatch::IntegrationTest
     assert_equal [{ name: 'E!', message: 'This is E.' }], @event.job.arguments
   end
 
-  if Gem::Version.new(Rails.version) > Gem::Version.new('7.0')
+  if Gem::Version.new(Rails.version) >= Gem::Version.new('7.1.0.alpha')
     test 'returns aborted' do
       get '/yay/123?aborted=true'
       assert @event.aborted

--- a/test/rails_band/active_job/event/perform_test.rb
+++ b/test/rails_band/active_job/event/perform_test.rb
@@ -78,10 +78,15 @@ class PerformTest < ActionDispatch::IntegrationTest
     assert_equal [{ name: 'JJ', message: 'Hi' }], @event.job.arguments
   end
 
-  if Gem::Version.new(Rails.version) > Gem::Version.new('7.0')
+  if Gem::Version.new(Rails.version) >= Gem::Version.new('7.1.0.alpha')
     test 'returns aborted' do
       YayJob.perform_now(name: 'JJ', message: 'Hi', aborted: true)
       assert @event.aborted
+    end
+
+    test 'returns db_runtime' do
+      YayJob.perform_now(name: 'JJ', message: 'Hi')
+      assert_instance_of Float, @event.db_runtime
     end
   end
 end


### PR DESCRIPTION
Close #93 

`:db_runtime` was added in the payload of `perform.active_job`, so make this gem support it.

I also updated the version condition to use `>= Gem::Version.new('7.1.0.alpha')` instead of `> Gem::Version.new('7.0')`. I think it would be better to specify the version that supports the feature, not the version that doesn't support it.