### PR TITLE
Disable `Style/RedundantConstantBase`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,4 +40,8 @@ Metrics/BlockLength:
 Style/IfUnlessModifier:
   Enabled: false
 
+# `Module.nesting` is empty in the current code, but we're not sure it will keep being that.
+Style/RedundantConstantBase:
+  Enabled: false
+
 # If you feel annoyed by the current configuration, let's tweak the configuration!


### PR DESCRIPTION
I understood the intention of this cop, but I'm not sure whether all constants of which `Module.nesting` is empty keep being empty or not.