### PR TITLE
Run `gem update --system` to use the latest RubyGems always

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-
-      - run: gem update --system
+          rubygems: latest
 
       - run: bundle exec rake test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
 
+      - run: gem update --system
+
       - run: bundle exec rake test
 
   lint:


### PR DESCRIPTION
Rails now [requires RubyGems 3.3.13 or higher](https://github.com/rails/rails/pull/46817), so the tests with the edge Rails fail like this:

https://github.com/yykamei/rails_band/actions/runs/3806811679/jobs/6475944216

I made the CIs to use the latest RubyGems always to satisfy the constraint.