### PR TITLE
Fix the access to `.action_on_strict_loading_violation`

### DIFF
--- a/test/rails_band/active_record/event/strict_loading_violation_test.rb
+++ b/test/rails_band/active_record/event/strict_loading_violation_test.rb
@@ -10,9 +10,12 @@ if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1')
         'strict_loading_violation.active_record': ->(event) { @event = event }
       }
       @user = User.create!(name: 'foo', email: 'foo@example.com')
-      ActiveSupport::Deprecation.silence do
+      if ActiveRecord.respond_to?(:action_on_strict_loading_violation)
         @old_ar_config = ActiveRecord.action_on_strict_loading_violation
         ActiveRecord.action_on_strict_loading_violation = :log
+      else
+        @old_ar_config = ActiveRecord::Base.action_on_strict_loading_violation
+        ActiveRecord::Base.action_on_strict_loading_violation = :log
       end
 
       Note.create!(user: @user, title: 'f')
@@ -20,8 +23,10 @@ if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1')
     end
 
     teardown do
-      ActiveSupport::Deprecation.silence do
+      if ActiveRecord.respond_to?(:action_on_strict_loading_violation)
         ActiveRecord.action_on_strict_loading_violation = @old_ar_config
+      else
+        ActiveRecord::Base.action_on_strict_loading_violation = @old_ar_config
       end
     end
 

--- a/test/rails_band/active_record/event/strict_loading_violation_test.rb
+++ b/test/rails_band/active_record/event/strict_loading_violation_test.rb
@@ -11,8 +11,8 @@ if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1')
       }
       @user = User.create!(name: 'foo', email: 'foo@example.com')
       ActiveSupport::Deprecation.silence do
-        @old_ar_config = ActiveRecord::Base.action_on_strict_loading_violation
-        ActiveRecord::Base.action_on_strict_loading_violation = :log
+        @old_ar_config = ActiveRecord.action_on_strict_loading_violation
+        ActiveRecord.action_on_strict_loading_violation = :log
       end
 
       Note.create!(user: @user, title: 'f')
@@ -21,7 +21,7 @@ if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1')
 
     teardown do
       ActiveSupport::Deprecation.silence do
-        ActiveRecord::Base.action_on_strict_loading_violation = @old_ar_config
+        ActiveRecord.action_on_strict_loading_violation = @old_ar_config
       end
     end
 


### PR DESCRIPTION
This patch fixes the error reported [here](https://github.com/yykamei/rails_band/actions/runs/4364290918/jobs/7631427866).

Since Rails 7, the access to `ActiveRecord::Base.action_on_strict_loading_violation` has been deprecated, and it's not allowed in Rails 7.1+. So, I changed the access to the method in the test code.
