### PR TITLE
Do not use the singleton methods on `ActiveSupport::Deprecation`

### DIFF
--- a/test/dummy/app/controllers/users_controller.rb
+++ b/test/dummy/app/controllers/users_controller.rb
@@ -94,8 +94,10 @@ class UsersController < ApplicationController
   end
 
   def deprecation
-    ActiveSupport::Deprecation.behavior = :notify
-    ActiveSupport::Deprecation.warn('deprecated!!!')
+    ActiveSupport::Deprecation.new('2.0').tap do |deprecator|
+      deprecator.behavior = :notify
+      deprecator.warn('deprecated!!!')
+    end
     redirect_to users_path
   end
 


### PR DESCRIPTION
I want to fix this error.

https://github.com/yykamei/rails_band/actions/runs/4678274420/jobs/8286810613

Since Rails 7.2, the use of the singleton method is deprecated.

https://github.com/rails/rails/blob/b20defada34699077a348a9cb274015878c7bbdc/activesupport/CHANGELOG.md?plain=1#L1