### PR TITLE
Support enqueue_all.active_job

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 | [`perform.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#perform-active-job)             | ✅        |
 | [`retry_stopped.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#retry-stopped-active-job) | ✅        |
 | [`discard.active_job`](https://guides.rubyonrails.org/active_support_instrumentation.html#discard-active-job)             | ✅        |
-| [`enqueue_all.active_job`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#enqueue-all-active-job)                       |           |
+| [`enqueue_all.active_job`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#enqueue-all-active-job) | ✅        |
 
 ### Action Cable
 

--- a/lib/rails_band/active_job/event/enqueue_all.rb
+++ b/lib/rails_band/active_job/event/enqueue_all.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActiveJob
+    module Event
+      # A wrapper for the event that is passed to `enqueue.active_job`.
+      class EnqueueAll < BaseEvent
+        def adapter
+          @adapter ||= @event.payload.fetch(:adapter)
+        end
+
+        def jobs
+          @jobs ||= @event.payload.fetch(:jobs)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/active_job/log_subscriber.rb
+++ b/lib/rails_band/active_job/log_subscriber.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_band/active_job/event/enqueue_at'
+require 'rails_band/active_job/event/enqueue_all'
 require 'rails_band/active_job/event/enqueue'
 require 'rails_band/active_job/event/enqueue_retry'
 require 'rails_band/active_job/event/perform_start'
@@ -40,6 +41,10 @@ module RailsBand
 
       def discard(event)
         consumer_of(__method__)&.call(Event::Discard.new(event))
+      end
+
+      def enqueue_all(event)
+        consumer_of(__method__)&.call(Event::EnqueueAll.new(event))
       end
 
       private

--- a/test/dummy/app/controllers/yay_controller.rb
+++ b/test/dummy/app/controllers/yay_controller.rb
@@ -10,6 +10,10 @@ class YayController < ApplicationController
   def show
     aborted = ActiveModel::Type::Boolean.new.cast(params[:aborted])
     YayJob.perform_later(name: 'E!', message: 'This is E.', **{ aborted: aborted }.compact)
+
+    if Gem::Version.new(Rails.version) >= Gem::Version.new('7.1.0.alpha')
+      ActiveJob.perform_all_later(YayJob.new(name: 'F!', message: 'This is F.'))
+    end
     head :no_content
   end
 end

--- a/test/rails_band/active_job/event/enqueue_all_test.rb
+++ b/test/rails_band/active_job/event/enqueue_all_test.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+if Gem::Version.new(Rails.version) >= Gem::Version.new('7.1.0.alpha')
+  class EnqueueAllTest < ActionDispatch::IntegrationTest
+    setup do
+      @event = nil
+      RailsBand::ActiveJob::LogSubscriber.consumers = {
+        'enqueue_all.active_job': ->(event) { @event = event }
+      }
+    end
+
+    test 'returns name' do
+      get '/yay/123'
+
+      assert_equal 'enqueue_all.active_job', @event.name
+    end
+
+    test 'returns time' do
+      get '/yay/123'
+
+      assert_instance_of Float, @event.time
+    end
+
+    test 'returns end' do
+      get '/yay/123'
+
+      assert_instance_of Float, @event.end
+    end
+
+    test 'returns transaction_id' do
+      get '/yay/123'
+
+      assert_instance_of String, @event.transaction_id
+    end
+
+    test 'returns cpu_time' do
+      get '/yay/123'
+
+      assert_instance_of Float, @event.cpu_time
+    end
+
+    test 'returns idle_time' do
+      get '/yay/123'
+
+      assert_instance_of Float, @event.idle_time
+    end
+
+    test 'returns allocations' do
+      get '/yay/123'
+
+      assert_instance_of Integer, @event.allocations
+    end
+
+    test 'returns duration' do
+      get '/yay/123'
+
+      assert_instance_of Float, @event.duration
+    end
+
+    test 'calls #to_h' do
+      get '/yay/123'
+
+      %i[name time end transaction_id cpu_time idle_time allocations duration adapter jobs].each do |key|
+        assert_includes @event.to_h, key
+      end
+    end
+
+    test 'calls #slice' do
+      get '/yay/123'
+
+      assert_equal({ name: 'enqueue_all.active_job' }, @event.slice(:name))
+    end
+
+    test 'returns an instance of EnqueueAll' do
+      get '/yay/123'
+
+      assert_instance_of RailsBand::ActiveJob::Event::EnqueueAll, @event
+    end
+
+    test 'returns adapter' do
+      get '/yay/123'
+
+      assert_instance_of ::ActiveJob::QueueAdapters::TestAdapter, @event.adapter
+    end
+
+    test 'returns jobs' do
+      get '/yay/123'
+
+      assert_instance_of YayJob, @event.jobs
+      assert_equal [{ name: 'F!', message: 'This is F.' }], @event.jobs.map(&:arguments)
+    end
+  end
+end


### PR DESCRIPTION
Support [`enqueue_all.active_job`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#enqueue-all-active-job).