### PR TITLE
Set explicit string key for Rails cache

### DIFF
--- a/test/dummy/app/controllers/users_controller.rb
+++ b/test/dummy/app/controllers/users_controller.rb
@@ -70,7 +70,7 @@ class UsersController < ApplicationController
 
   def cache
     user = User.find(params.require(:user_id))
-    result = Rails.cache.fetch(user.id, expires_in: 1.minutes) do
+    result = Rails.cache.fetch("key_#{user.id}", expires_in: 1.minutes) do
       user.slow_method
     end
     logger.info(result)

--- a/test/rails_band/active_support/event/cache_generate_test.rb
+++ b/test/rails_band/active_support/event/cache_generate_test.rb
@@ -82,7 +82,7 @@ class CacheGenerateTest < ActionDispatch::IntegrationTest
   test 'returns key' do
     get "/users/#{@user.id}/cache"
 
-    assert_equal @user.id, @event.key
+    assert_equal "key_#{@user.id}", @event.key
   end
 
   if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1')

--- a/test/rails_band/active_support/event/cache_read_test.rb
+++ b/test/rails_band/active_support/event/cache_read_test.rb
@@ -82,7 +82,7 @@ class CacheReadTest < ActionDispatch::IntegrationTest
   test 'returns key' do
     get "/users/#{@user.id}/cache"
 
-    assert_equal @user.id, @event.key
+    assert_equal "key_#{@user.id}", @event.key
   end
 
   if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1')


### PR DESCRIPTION
Thanks to https://github.com/rails/rails/pull/50008, I found that the Rails cache key should be treated as String. This patch changes the Rails cache to set String instead of Integer to follow the expected cache key type.