### PR TITLE
Do not use latest rubygems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-          rubygems: latest
 
       - run: bundle exec rake test
 


### PR DESCRIPTION
Fix this error: https://github.com/yykamei/rails_band/actions/runs/7231903841/job/19705659576

The latest rubygems has dropped Ruby 2.6 and 2.7, so `rubygems: latest` doesn't work in older Ruby runtimes.

https://github.com/rubygems/rubygems/releases/tag/v3.5.0
