### PR TITLE
Exclude CI matrix with old Ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
             rails: '7.1'
           - ruby: '2.6'
             rails: 'edge'
+          - ruby: '2.7'
+            rails: 'edge'
+          - ruby: '3.0'
+            rails: 'edge'
     env:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.gemfile
 


### PR DESCRIPTION
Now, the edge version of Rails supports Ruby 3.1+.