### PR TITLE
Exclude Ruby=2.7 and rails=7.1 from CI strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
           - ruby: '2.6'
             rails: 'edge'
           - ruby: '2.7'
+            rails: '7.1'
+          - ruby: '2.7'
             rails: 'edge'
           - ruby: '3.0'
             rails: 'edge'


### PR DESCRIPTION
This fixes https://github.com/yykamei/rails_band/actions/runs/7665300450.

Due to https://github.com/sparklemotion/sqlite3-ruby/pull/431, Ruby 2.7 is not shipped in the native gem. Maybe, I can still ship sqlite3-ruby without native gem, but I don't want to write a code for it. So, I just excluded the combination from the CI strategy matrix.