### PR TITLE
Add a symbolic link to test.png for Rails edge

### DIFF
--- a/test/dummy/test/fixtures/files/test.png
+++ b/test/dummy/test/fixtures/files/test.png
@@ -1,0 +1,1 @@
+../../../../fixtures/files/test.png


### PR DESCRIPTION
I'm not sure why 🤷, but the Rails edge tries to refer to files in the directory `test/dummy/test/fixtures/files`.