### PR TITLE
Support send_stream.action_controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 | [`start_processing.action_controller`](https://guides.rubyonrails.org/active_support_instrumentation.html#start-processing-action-controller)             | ✅        |
 | [`process_action.action_controller`](https://guides.rubyonrails.org/active_support_instrumentation.html#process-action-action-controller)                 | ✅        |
 | [`send_file.action_controller`](https://guides.rubyonrails.org/active_support_instrumentation.html#send-file-action-controller)                           | ✅        |
+| [`send_stream.action_controller`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#send-stream-action-controller)                   | ✅        |
 | [`send_data.action_controller`](https://guides.rubyonrails.org/active_support_instrumentation.html#send-data-action-controller)                           | ✅        |
 | [`redirect_to.action_controller`](https://guides.rubyonrails.org/active_support_instrumentation.html#redirect-to-action-controller)                       | ✅        |
 | [`halted_callback.action_controller`](https://guides.rubyonrails.org/active_support_instrumentation.html#halted-callback-action-controller)               | ✅        |

--- a/lib/rails_band/action_controller/event/send_stream.rb
+++ b/lib/rails_band/action_controller/event/send_stream.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActionController
+    module Event
+      # A wrapper for the event that is passed to `send_stream.action_controller`.
+      class SendStream < BaseEvent
+
+        def filename
+          return @filename if defined? @filename
+
+          @filename = @event.payload[:filename]
+        end
+
+        def type
+          return @type if defined? @type
+
+          @type = @event.payload[:type]
+        end
+
+        def disposition
+          return @disposition if defined? @disposition
+
+          @disposition = @event.payload[:disposition]
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/action_controller/log_subscriber.rb
+++ b/lib/rails_band/action_controller/log_subscriber.rb
@@ -7,6 +7,7 @@ require 'rails_band/action_controller/event/exist_fragment'
 require 'rails_band/action_controller/event/start_processing'
 require 'rails_band/action_controller/event/process_action'
 require 'rails_band/action_controller/event/send_file'
+require 'rails_band/action_controller/event/send_stream'
 require 'rails_band/action_controller/event/send_data'
 require 'rails_band/action_controller/event/redirect_to'
 require 'rails_band/action_controller/event/halted_callback'
@@ -48,6 +49,10 @@ module RailsBand
 
       def send_file(event)
         consumer_of(__method__)&.call(Event::SendFile.new(event))
+      end
+
+      def send_stream(event)
+        consumer_of(__method__)&.call(Event::SendStream.new(event))
       end
 
       def send_data(event)

--- a/test/dummy/app/controllers/special_stream_controller.rb
+++ b/test/dummy/app/controllers/special_stream_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class SpecialStreamController < ApplicationController
+  include ActionController::Live
+
+  def index
+    send_stream filename: 'special.txt' do |stream|
+      10.times do
+        stream.write "a\n"
+      end
+    end
+  end
+end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -23,4 +23,5 @@ Rails.application.routes.draw do
   post '/teams/transform', to: 'teams#transform'
 
   get 'old_users', to: redirect('/users')
+  get 'special_stream', to: 'special_stream#index'
 end

--- a/test/rails_band/action_controller/event/send_stream_test.rb
+++ b/test/rails_band/action_controller/event/send_stream_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+if Gem::Version.new(Rails.version) >= Gem::Version.new('7.2.0.alpha')
+  class SendStreamTest < ActionDispatch::IntegrationTest
+    setup do
+      @event = nil
+      RailsBand::ActionController::LogSubscriber.consumers = {
+        'send_stream.action_controller': ->(event) { @event = event }
+      }
+    end
+
+    test 'returns name' do
+      get '/special_stream'
+
+      assert_equal 'send_stream.action_controller', @event.name
+    end
+
+    test 'returns time' do
+      get '/special_stream'
+
+      assert_instance_of Float, @event.time
+    end
+
+    test 'returns end' do
+      get '/special_stream'
+
+      assert_instance_of Float, @event.end
+    end
+
+    test 'returns transaction_id' do
+      get '/special_stream'
+
+      assert_instance_of String, @event.transaction_id
+    end
+
+    test 'returns cpu_time' do
+      get '/special_stream'
+
+      assert_instance_of Float, @event.cpu_time
+    end
+
+    test 'returns idle_time' do
+      get '/special_stream'
+
+      assert_instance_of Float, @event.idle_time
+    end
+
+    test 'returns allocations' do
+      get '/special_stream'
+
+      assert_instance_of Integer, @event.allocations
+    end
+
+    test 'returns duration' do
+      get '/special_stream'
+
+      assert_instance_of Float, @event.duration
+    end
+
+    test 'calls #to_h' do
+      get '/special_stream'
+
+      %i[name time end transaction_id cpu_time idle_time allocations duration
+       filename type disposition].each do |key|
+        assert_includes @event.to_h, key
+      end
+    end
+
+    test 'calls #slice' do
+      get '/special_stream'
+
+      assert_equal({ name: 'send_stream.action_controller' }, @event.slice(:name))
+    end
+
+    test 'returns an instance of SendStream' do
+      get '/special_stream'
+
+      assert_instance_of RailsBand::ActionController::Event::SendStream, @event
+    end
+
+    test 'returns filename' do
+      get '/special_stream'
+
+      assert_equal 'special.txt', @event.filename
+    end
+
+    test 'returns type' do
+      get '/special_stream'
+
+      assert_nil @event.type
+    end
+
+    test 'returns disposition' do
+      get '/special_stream'
+
+      assert_equal 'attachment', @event.disposition
+    end
+  end
+end


### PR DESCRIPTION
Close #125

Support [send_stream.action_controller](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#send-stream-action-controller).