### PR TITLE
Pin sqlite3 version for old Rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,5 @@ group :development do
   gem 'mini_magick'
   gem 'rubocop', require: false
   gem 'rubocop-minitest', require: false
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.4'
 end

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -8,6 +8,6 @@ gem 'net-smtp', require: false if RUBY_VERSION >= '3.1'
 gem 'psych', '~> 3.0'
 gem 'puma'
 gem 'rails', '~> 6.0.0'
-gem 'sqlite3'
+gem 'sqlite3', '~> 1.4'
 
 gemspec path: '../'

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -7,6 +7,6 @@ gem 'mini_magick'
 gem 'net-smtp', require: false if RUBY_VERSION >= '3.1'
 gem 'puma'
 gem 'rails', '~> 6.1.0'
-gem 'sqlite3'
+gem 'sqlite3', '~> 1.4'
 
 gemspec path: '../'

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -6,6 +6,6 @@ gem 'image_processing', '~> 1.2'
 gem 'mini_magick'
 gem 'puma'
 gem 'rails', '~> 7.0.0'
-gem 'sqlite3'
+gem 'sqlite3', '~> 1.4'
 
 gemspec path: '../'

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -6,6 +6,6 @@ gem 'image_processing', '~> 1.2'
 gem 'mini_magick'
 gem 'puma'
 gem 'rails', '~> 7.1.0'
-gem 'sqlite3'
+gem 'sqlite3', '~> 1.4'
 
 gemspec path: '../'


### PR DESCRIPTION
The new sqlite3 v2 has been [released](https://rubygems.org/gems/sqlite3/versions/2.0.0) 🎉

This is [incompatible](https://github.com/yykamei/rails_band/actions/runs/8753523577/job/24023398926) with old Rails, so I pinned the version to v1 to run CIs successfully.
