### PR TITLE
Use GitHub App installation token for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release
+run-name: Release v${{ inputs.version }} with apply=${{ inputs.apply }}
 on:
   workflow_dispatch:
     inputs:
@@ -15,9 +16,15 @@ jobs:
       contents: write
       id-token: write
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PAT_FOR_RELEASE }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: rubygems/configure-rubygems-credentials@v1.0.0
 
@@ -32,7 +39,7 @@ jobs:
           # frozen_string_literal: true
 
           module RailsBand
-            VERSION = '${{ github.event.inputs.version }}'
+            VERSION = '${{ inputs.version }}'
           end
           RUBY
 
@@ -40,16 +47,17 @@ jobs:
 
       - uses: yykamei/actions-git-push@main
         with:
-          commit-message: Bump to ${{ github.event.inputs.version }}
-        if: github.event.inputs.apply == 'true'
+          commit-message: Bump to ${{ inputs.version }}
+        if: inputs.apply
 
       - run: gem build rails_band.gemspec
 
       - run: gem push ./*.gem
-        if: github.event.inputs.apply == 'true'
+        if: inputs.apply
 
       - uses: yykamei/actions-release-actions@main
         with:
-          tag: v${{ github.event.inputs.version }}
-          apply: ${{ github.event.inputs.apply }}
+          token: ${{ steps.app-token.outputs.token }}
+          tag: v${{ inputs.version }}
+          apply: ${{ inputs.apply }}
           overwrite-major-minor: 'false'


### PR DESCRIPTION
Using fine-grained personal access token is a bit drudgery because it requires renew due to expiration. I decided to use GitHub App installation token instead because with a private key, I don't have to rotate a token.