### PR TITLE
Support request.action_dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 | --------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
 | [`process_middleware.action_dispatch`](https://guides.rubyonrails.org/active_support_instrumentation.html#process-middleware-action-dispatch) | ✅        |
 | [`redirect.action_dispatch`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#redirect-action-dispatch)                 | ✅        |
-| [`request.action_dispatch`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#request-action-dispatch)                   |           |
+| [`request.action_dispatch`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#request-action-dispatch)                   | ✅        |
 
 ### Action View
 

--- a/lib/rails_band/action_dispatch/event/request.rb
+++ b/lib/rails_band/action_dispatch/event/request.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActionDispatch
+    module Event
+      # A wrapper for the event that is passed to `redirect.action_dispatch`.
+      class Request < BaseEvent
+        def request
+          @request ||= @event.payload.fetch(:request)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/action_dispatch/log_subscriber.rb
+++ b/lib/rails_band/action_dispatch/log_subscriber.rb
@@ -2,6 +2,7 @@
 
 require 'rails_band/action_dispatch/event/process_middleware'
 require 'rails_band/action_dispatch/event/redirect'
+require 'rails_band/action_dispatch/event/request'
 
 module RailsBand
   module ActionDispatch
@@ -15,6 +16,10 @@ module RailsBand
 
       def redirect(event)
         consumer_of(__method__)&.call(Event::Redirect.new(event))
+      end
+
+      def request(event)
+        consumer_of(__method__)&.call(Event::Request.new(event))
       end
 
       private

--- a/test/rails_band/action_dispatch/event/request_test.rb
+++ b/test/rails_band/action_dispatch/event/request_test.rb
@@ -2,85 +2,87 @@
 
 require 'test_helper'
 
-class RequestTest < ActionDispatch::IntegrationTest
-  setup do
-    @event = nil
-    RailsBand::ActionDispatch::LogSubscriber.consumers = {
-      'request.action_dispatch': ->(event) { @event = event }
-    }
-  end
-
-  test 'returns name' do
-    get '/old_users'
-
-    assert_equal 'request.action_dispatch', @event.name
-  end
-
-  test 'returns time' do
-    get '/old_users'
-
-    assert_instance_of Float, @event.time
-  end
-
-  test 'returns end' do
-    get '/old_users'
-
-    assert_instance_of Float, @event.end
-  end
-
-  test 'returns transaction_id' do
-    get '/old_users'
-
-    assert_instance_of String, @event.transaction_id
-  end
-
-  test 'returns cpu_time' do
-    get '/old_users'
-
-    assert_instance_of Float, @event.cpu_time
-  end
-
-  test 'returns idle_time' do
-    get '/old_users'
-
-    assert_instance_of Float, @event.idle_time
-  end
-
-  test 'returns allocations' do
-    get '/old_users'
-
-    assert_instance_of Integer, @event.allocations
-  end
-
-  test 'returns duration' do
-    get '/old_users'
-
-    assert_instance_of Float, @event.duration
-  end
-
-  test 'calls #to_h' do
-    get '/old_users'
-
-    %i[name time end transaction_id cpu_time idle_time allocations duration request].each do |key|
-      assert_includes @event.to_h, key
+if Gem::Version.new(Rails.version) >= Gem::Version.new('7.1.0')
+  class RequestTest < ActionDispatch::IntegrationTest
+    setup do
+      @event = nil
+      RailsBand::ActionDispatch::LogSubscriber.consumers = {
+        'request.action_dispatch': ->(event) { @event = event }
+      }
     end
-  end
 
-  test 'calls #slice' do
-    get '/old_users'
+    test 'returns name' do
+      get '/old_users'
 
-    assert_equal({ name: 'request.action_dispatch' }, @event.slice(:name))
-  end
+      assert_equal 'request.action_dispatch', @event.name
+    end
 
-  test 'returns an instance of Request' do
-    get '/old_users'
+    test 'returns time' do
+      get '/old_users'
 
-    assert_instance_of RailsBand::ActionDispatch::Event::Request, @event
-  end
+      assert_instance_of Float, @event.time
+    end
 
-  test 'returns the request' do
-    get '/old_users'
+    test 'returns end' do
+      get '/old_users'
 
-    assert_kind_of ::ActionDispatch::Request, @event.request
+      assert_instance_of Float, @event.end
+    end
+
+    test 'returns transaction_id' do
+      get '/old_users'
+
+      assert_instance_of String, @event.transaction_id
+    end
+
+    test 'returns cpu_time' do
+      get '/old_users'
+
+      assert_instance_of Float, @event.cpu_time
+    end
+
+    test 'returns idle_time' do
+      get '/old_users'
+
+      assert_instance_of Float, @event.idle_time
+    end
+
+    test 'returns allocations' do
+      get '/old_users'
+
+      assert_instance_of Integer, @event.allocations
+    end
+
+    test 'returns duration' do
+      get '/old_users'
+
+      assert_instance_of Float, @event.duration
+    end
+
+    test 'calls #to_h' do
+      get '/old_users'
+
+      %i[name time end transaction_id cpu_time idle_time allocations duration request].each do |key|
+        assert_includes @event.to_h, key
+      end
+    end
+
+    test 'calls #slice' do
+      get '/old_users'
+
+      assert_equal({ name: 'request.action_dispatch' }, @event.slice(:name))
+    end
+
+    test 'returns an instance of Request' do
+      get '/old_users'
+
+      assert_instance_of RailsBand::ActionDispatch::Event::Request, @event
+    end
+
+    test 'returns the request' do
+      get '/old_users'
+
+      assert_kind_of ::ActionDispatch::Request, @event.request
+    end
   end
 end

--- a/test/rails_band/action_dispatch/event/request_test.rb
+++ b/test/rails_band/action_dispatch/event/request_test.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RequestTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = nil
+    RailsBand::ActionDispatch::LogSubscriber.consumers = {
+      'request.action_dispatch': ->(event) { @event = event }
+    }
+  end
+
+  test 'returns name' do
+    get '/old_users'
+
+    assert_equal 'request.action_dispatch', @event.name
+  end
+
+  test 'returns time' do
+    get '/old_users'
+
+    assert_instance_of Float, @event.time
+  end
+
+  test 'returns end' do
+    get '/old_users'
+
+    assert_instance_of Float, @event.end
+  end
+
+  test 'returns transaction_id' do
+    get '/old_users'
+
+    assert_instance_of String, @event.transaction_id
+  end
+
+  test 'returns cpu_time' do
+    get '/old_users'
+
+    assert_instance_of Float, @event.cpu_time
+  end
+
+  test 'returns idle_time' do
+    get '/old_users'
+
+    assert_instance_of Float, @event.idle_time
+  end
+
+  test 'returns allocations' do
+    get '/old_users'
+
+    assert_instance_of Integer, @event.allocations
+  end
+
+  test 'returns duration' do
+    get '/old_users'
+
+    assert_instance_of Float, @event.duration
+  end
+
+  test 'calls #to_h' do
+    get '/old_users'
+
+    %i[name time end transaction_id cpu_time idle_time allocations duration request].each do |key|
+      assert_includes @event.to_h, key
+    end
+  end
+
+  test 'calls #slice' do
+    get '/old_users'
+
+    assert_equal({ name: 'request.action_dispatch' }, @event.slice(:name))
+  end
+
+  test 'returns an instance of Request' do
+    get '/old_users'
+
+    assert_instance_of RailsBand::ActionDispatch::Event::Request, @event
+  end
+
+  test 'returns the request' do
+    get '/old_users'
+
+    assert_kind_of ::ActionDispatch::Request, @event.request
+  end
+end


### PR DESCRIPTION
Close #133

https://edgeguides.rubyonrails.org/active_support_instrumentation.html#request-action-dispatch

`Rails::Rack::Logger` calls an instrumentation API with the event named `request.action_dispatch`. With this pull request, rails_band now catches this event.

I only tested for Rails >= 7.1.0 because I couldn't run the tests for the event 🤷 