### PR TITLE
Support cache_increment.active_support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 | [`cache_fetch_hit.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-fetch-hit-active-support)               | ✅        |
 | [`cache_write.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-write-active-support)                       | ✅        |
 | [`cache_write_multi.active_support`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-write-multi-active-support)       | ✅        |
-| [`cache_increment.active_support`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-increment-active-support)           |           |
+| [`cache_increment.active_support`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-increment-active-support)           | ✅        |
 | [`cache_decrement.active_support `](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-decrement-active-support)          |           |
 | [`cache_delete.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-delete-active-support)                     | ✅        |
 | [`cache_delete_multi.active_support`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-delete-multi-active-support)     | ✅        |

--- a/lib/rails_band/active_support/event/cache_increment.rb
+++ b/lib/rails_band/active_support/event/cache_increment.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActiveSupport
+    module Event
+      # A wrapper for the event that is passed to `cache_increment.active_support`.
+      class CacheIncrement < BaseEvent
+        def key
+          @key ||= @event.payload.fetch(:key)
+        end
+
+        def store
+          @store ||= @event.payload.fetch(:store)
+        end
+
+        def amount
+          @amount ||= @event.payload.fetch(:amount)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/active_support/log_subscriber.rb
+++ b/lib/rails_band/active_support/log_subscriber.rb
@@ -6,6 +6,7 @@ require 'rails_band/active_support/event/cache_generate'
 require 'rails_band/active_support/event/cache_fetch_hit'
 require 'rails_band/active_support/event/cache_write'
 require 'rails_band/active_support/event/cache_write_multi'
+require 'rails_band/active_support/event/cache_increment'
 require 'rails_band/active_support/event/cache_delete'
 require 'rails_band/active_support/event/cache_delete_multi'
 require 'rails_band/active_support/event/cache_exist'
@@ -38,6 +39,10 @@ module RailsBand
 
       def cache_write_multi(event)
         consumer_of(__method__)&.call(Event::CacheWriteMulti.new(event))
+      end
+
+      def cache_increment(event)
+        consumer_of(__method__)&.call(Event::CacheIncrement.new(event))
       end
 
       def cache_delete(event)

--- a/lib/rails_band/configuration.rb
+++ b/lib/rails_band/configuration.rb
@@ -10,7 +10,7 @@ module RailsBand
           raise ArgumentError, "The value for `#{key.inspect}` must have #call: the passed one is `#{value.inspect}`"
         end
 
-        super(key, value)
+        super
       end
     end
 

--- a/test/dummy/app/controllers/users_controller.rb
+++ b/test/dummy/app/controllers/users_controller.rb
@@ -93,6 +93,20 @@ class UsersController < ApplicationController
     redirect_to users_path
   end
 
+  def cache4
+    # HACK: cache_increment and cache_decrement events are emitted when using MemCacheStore or RedisCacheStore.
+    #       This code simulates the events.
+    ActiveSupport::Notifications.instrument('cache_increment.active_support',
+                                            { key: 'INC1', store: 'ActiveSupport::Cache::RedisCacheStore', amount: 1 }) do
+      # noop
+    end
+    ActiveSupport::Notifications.instrument('cache_decrement.active_support',
+                                            { key: 'DEC1', store: 'ActiveSupport::Cache::RedisCacheStore', amount: 1 }) do
+      # noop
+    end
+    redirect_to users_path
+  end
+
   def deprecation
     ActiveSupport::Deprecation.new('2.0').tap do |deprecator|
       deprecator.behavior = :notify

--- a/test/dummy/app/controllers/users_controller.rb
+++ b/test/dummy/app/controllers/users_controller.rb
@@ -97,11 +97,11 @@ class UsersController < ApplicationController
     # HACK: cache_increment and cache_decrement events are emitted when using MemCacheStore or RedisCacheStore.
     #       This code simulates the events.
     ActiveSupport::Notifications.instrument('cache_increment.active_support',
-                                            { key: 'INC1', store: 'ActiveSupport::Cache::RedisCacheStore', amount: 1 }) do
+                                            { key: 'INC1', store: 'RedisCacheStore', amount: 1 }) do
       # noop
     end
     ActiveSupport::Notifications.instrument('cache_decrement.active_support',
-                                            { key: 'DEC1', store: 'ActiveSupport::Cache::RedisCacheStore', amount: 1 }) do
+                                            { key: 'DEC1', store: 'RedisCacheStore', amount: 1 }) do
       # noop
     end
     redirect_to users_path

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     get :cache
     get :cache2
     get :cache3
+    get :cache4
     get :deprecation
   end
 

--- a/test/rails_band/active_support/event/cache_increment_test.rb
+++ b/test/rails_band/active_support/event/cache_increment_test.rb
@@ -87,7 +87,7 @@ class CacheIncrementTest < ActionDispatch::IntegrationTest
   test 'returns store' do
     get '/users/123/cache4'
 
-    assert_equal 'ActiveSupport::Cache::RedisCacheStore', @event.store
+    assert_equal 'RedisCacheStore', @event.store
   end
 
   test 'returns amount' do

--- a/test/rails_band/active_support/event/cache_increment_test.rb
+++ b/test/rails_band/active_support/event/cache_increment_test.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CacheIncrementTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = nil
+    RailsBand::ActiveSupport::LogSubscriber.consumers = {
+      'cache_increment.active_support': ->(event) { @event = event }
+    }
+  end
+
+  test 'returns name' do
+    get '/users/123/cache4'
+
+    assert_equal 'cache_increment.active_support', @event.name
+  end
+
+  test 'returns time' do
+    get '/users/123/cache4'
+
+    assert_instance_of Float, @event.time
+  end
+
+  test 'returns end' do
+    get '/users/123/cache4'
+
+    assert_instance_of Float, @event.end
+  end
+
+  test 'returns transaction_id' do
+    get '/users/123/cache4'
+
+    assert_instance_of String, @event.transaction_id
+  end
+
+  test 'returns cpu_time' do
+    get '/users/123/cache4'
+
+    assert_instance_of Float, @event.cpu_time
+  end
+
+  test 'returns idle_time' do
+    get '/users/123/cache4'
+
+    assert_instance_of Float, @event.idle_time
+  end
+
+  test 'returns allocations' do
+    get '/users/123/cache4'
+
+    assert_instance_of Integer, @event.allocations
+  end
+
+  test 'returns duration' do
+    get '/users/123/cache4'
+
+    assert_instance_of Float, @event.duration
+  end
+
+  test 'calls #to_h' do
+    get '/users/123/cache4'
+
+    %i[name time end transaction_id cpu_time idle_time allocations duration key store amount].each do |key|
+      assert_includes @event.to_h, key
+    end
+  end
+
+  test 'calls #slice' do
+    get '/users/123/cache4'
+
+    assert_equal({ name: 'cache_increment.active_support' }, @event.slice(:name))
+  end
+
+  test 'returns an instance of CacheIncrement' do
+    get '/users/123/cache4'
+
+    assert_instance_of RailsBand::ActiveSupport::Event::CacheIncrement, @event
+  end
+
+  test 'returns key' do
+    get '/users/123/cache4'
+
+    assert_equal('INC1', @event.key)
+  end
+
+  test 'returns store' do
+    get '/users/123/cache4'
+
+    assert_equal 'ActiveSupport::Cache::RedisCacheStore', @event.store
+  end
+
+  test 'returns amount' do
+    get '/users/123/cache4'
+
+    assert_equal 1, @event.amount
+  end
+end


### PR DESCRIPTION
Close https://github.com/yykamei/rails_band/issues/134

With this change, [`cache_increment.active_support`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-increment-active-support) will be supported.
