### PR TITLE
Support cache_decrement.active_support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'rails', github: 'rails/rails'
+
 group :development do
   gem 'image_processing', '~> 1.2'
   gem 'mini_magick'

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 | [`cache_write.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-write-active-support)                       | ✅        |
 | [`cache_write_multi.active_support`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-write-multi-active-support)       | ✅        |
 | [`cache_increment.active_support`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-increment-active-support)           | ✅        |
-| [`cache_decrement.active_support `](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-decrement-active-support)          |           |
+| [`cache_decrement.active_support `](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-decrement-active-support)          | ✅        |
 | [`cache_delete.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-delete-active-support)                     | ✅        |
 | [`cache_delete_multi.active_support`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-delete-multi-active-support)     | ✅        |
 | [`cache_delete_matched.active_support`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-delete-matched-active-support) |           |

--- a/lib/rails_band/active_support/event/cache_decrement.rb
+++ b/lib/rails_band/active_support/event/cache_decrement.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActiveSupport
+    module Event
+      # A wrapper for the event that is passed to `cache_decrement.active_support`.
+      class CacheDecrement < BaseEvent
+        def key
+          @key ||= @event.payload.fetch(:key)
+        end
+
+        def store
+          @store ||= @event.payload.fetch(:store)
+        end
+
+        def amount
+          @amount ||= @event.payload.fetch(:amount)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/active_support/log_subscriber.rb
+++ b/lib/rails_band/active_support/log_subscriber.rb
@@ -7,6 +7,7 @@ require 'rails_band/active_support/event/cache_fetch_hit'
 require 'rails_band/active_support/event/cache_write'
 require 'rails_band/active_support/event/cache_write_multi'
 require 'rails_band/active_support/event/cache_increment'
+require 'rails_band/active_support/event/cache_decrement'
 require 'rails_band/active_support/event/cache_delete'
 require 'rails_band/active_support/event/cache_delete_multi'
 require 'rails_band/active_support/event/cache_exist'
@@ -43,6 +44,10 @@ module RailsBand
 
       def cache_increment(event)
         consumer_of(__method__)&.call(Event::CacheIncrement.new(event))
+      end
+
+      def cache_decrement(event)
+        consumer_of(__method__)&.call(Event::CacheDecrement.new(event))
       end
 
       def cache_delete(event)

--- a/test/rails_band/active_support/event/cache_decrement_test.rb
+++ b/test/rails_band/active_support/event/cache_decrement_test.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CacheDecrementTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = nil
+    RailsBand::ActiveSupport::LogSubscriber.consumers = {
+      'cache_decrement.active_support': ->(event) { @event = event }
+    }
+  end
+
+  test 'returns name' do
+    get '/users/123/cache4'
+
+    assert_equal 'cache_decrement.active_support', @event.name
+  end
+
+  test 'returns time' do
+    get '/users/123/cache4'
+
+    assert_instance_of Float, @event.time
+  end
+
+  test 'returns end' do
+    get '/users/123/cache4'
+
+    assert_instance_of Float, @event.end
+  end
+
+  test 'returns transaction_id' do
+    get '/users/123/cache4'
+
+    assert_instance_of String, @event.transaction_id
+  end
+
+  test 'returns cpu_time' do
+    get '/users/123/cache4'
+
+    assert_instance_of Float, @event.cpu_time
+  end
+
+  test 'returns idle_time' do
+    get '/users/123/cache4'
+
+    assert_instance_of Float, @event.idle_time
+  end
+
+  test 'returns allocations' do
+    get '/users/123/cache4'
+
+    assert_instance_of Integer, @event.allocations
+  end
+
+  test 'returns duration' do
+    get '/users/123/cache4'
+
+    assert_instance_of Float, @event.duration
+  end
+
+  test 'calls #to_h' do
+    get '/users/123/cache4'
+
+    %i[name time end transaction_id cpu_time idle_time allocations duration key store amount].each do |key|
+      assert_includes @event.to_h, key
+    end
+  end
+
+  test 'calls #slice' do
+    get '/users/123/cache4'
+
+    assert_equal({ name: 'cache_decrement.active_support' }, @event.slice(:name))
+  end
+
+  test 'returns an instance of CacheDecrement' do
+    get '/users/123/cache4'
+
+    assert_instance_of RailsBand::ActiveSupport::Event::CacheDecrement, @event
+  end
+
+  test 'returns key' do
+    get '/users/123/cache4'
+
+    assert_equal('DEC1', @event.key)
+  end
+
+  test 'returns store' do
+    get '/users/123/cache4'
+
+    assert_equal 'RedisCacheStore', @event.store
+  end
+
+  test 'returns amount' do
+    get '/users/123/cache4'
+
+    assert_equal 1, @event.amount
+  end
+end


### PR DESCRIPTION
Close https://github.com/yykamei/rails_band/issues/135

With this change, [cache_decrement.active_support](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-decrement-active-support) will be supported.