### PR TITLE
Support cache_delete_matched.active_support

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 | [`cache_decrement.active_support `](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-decrement-active-support)          | ✅        |
 | [`cache_delete.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-delete-active-support)                     | ✅        |
 | [`cache_delete_multi.active_support`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-delete-multi-active-support)     | ✅        |
-| [`cache_delete_matched.active_support`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-delete-matched-active-support) |           |
+| [`cache_delete_matched.active_support`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-delete-matched-active-support) | ✅        |
 | [`cache_cleanup.active_support`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-cleanup-active-support)               |           |
 | [`cache_prune.active_support`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-prune-active-support)                   |           |
 | [`cache_exist?.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-exist-questionmark-active-support)         | ✅        |

--- a/lib/rails_band/active_support/event/cache_delete_matched.rb
+++ b/lib/rails_band/active_support/event/cache_delete_matched.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActiveSupport
+    module Event
+      # A wrapper for the event that is passed to `cache_delete_matched.active_support`.
+      class CacheDeleteMatched < BaseEvent
+        def key
+          @key ||= @event.payload.fetch(:key)
+        end
+
+        def store
+          @store ||= @event.payload.fetch(:store)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/active_support/log_subscriber.rb
+++ b/lib/rails_band/active_support/log_subscriber.rb
@@ -10,6 +10,7 @@ require 'rails_band/active_support/event/cache_increment'
 require 'rails_band/active_support/event/cache_decrement'
 require 'rails_band/active_support/event/cache_delete'
 require 'rails_band/active_support/event/cache_delete_multi'
+require 'rails_band/active_support/event/cache_delete_matched'
 require 'rails_band/active_support/event/cache_exist'
 
 module RailsBand
@@ -56,6 +57,10 @@ module RailsBand
 
       def cache_delete_multi(event)
         consumer_of(__method__)&.call(Event::CacheDeleteMulti.new(event))
+      end
+
+      def cache_delete_matched(event)
+        consumer_of(__method__)&.call(Event::CacheDeleteMatched.new(event))
       end
 
       def cache_exist?(event)

--- a/test/dummy/app/controllers/users_controller.rb
+++ b/test/dummy/app/controllers/users_controller.rb
@@ -104,6 +104,10 @@ class UsersController < ApplicationController
                                             { key: 'DEC1', store: 'RedisCacheStore', amount: 1 }) do
       # noop
     end
+    ActiveSupport::Notifications.instrument('cache_delete_matched.active_support',
+                                            { key: 'MyDeleteMatched', store: 'Store!' }) do
+      # noop
+    end
     redirect_to users_path
   end
 

--- a/test/rails_band/active_support/event/cache_delete_matched_test.rb
+++ b/test/rails_band/active_support/event/cache_delete_matched_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1')
+  class CacheDeleteMatchedTest < ActionDispatch::IntegrationTest
+    setup do
+      @event = nil
+      RailsBand::ActiveSupport::LogSubscriber.consumers = {
+        'cache_delete_matched.active_support': ->(event) { @event = event }
+      }
+    end
+
+    test 'returns name' do
+      get '/users/123/cache4'
+
+      assert_equal 'cache_delete_matched.active_support', @event.name
+    end
+
+    test 'returns time' do
+      get '/users/123/cache4'
+
+      assert_instance_of Float, @event.time
+    end
+
+    test 'returns end' do
+      get '/users/123/cache4'
+
+      assert_instance_of Float, @event.end
+    end
+
+    test 'returns transaction_id' do
+      get '/users/123/cache4'
+
+      assert_instance_of String, @event.transaction_id
+    end
+
+    test 'returns cpu_time' do
+      get '/users/123/cache4'
+
+      assert_instance_of Float, @event.cpu_time
+    end
+
+    test 'returns idle_time' do
+      get '/users/123/cache4'
+
+      assert_instance_of Float, @event.idle_time
+    end
+
+    test 'returns allocations' do
+      get '/users/123/cache4'
+
+      assert_instance_of Integer, @event.allocations
+    end
+
+    test 'returns duration' do
+      get '/users/123/cache4'
+
+      assert_instance_of Float, @event.duration
+    end
+
+    test 'calls #to_h' do
+      get '/users/123/cache4'
+
+      %i[name time end transaction_id cpu_time idle_time allocations duration key store].each do |key|
+        assert_includes @event.to_h, key
+      end
+    end
+
+    test 'calls #slice' do
+      get '/users/123/cache4'
+
+      assert_equal({ name: 'cache_delete_matched.active_support' }, @event.slice(:name))
+    end
+
+    test 'returns an instance of CacheDeleteMatched' do
+      get '/users/123/cache4'
+
+      assert_instance_of RailsBand::ActiveSupport::Event::CacheDeleteMatched, @event
+    end
+
+    test 'returns key' do
+      get '/users/123/cache4'
+
+      assert_equal 'MyDeleteMatched', @event.key
+    end
+
+    test 'returns store' do
+      get '/users/123/cache4'
+
+      assert_equal 'Store!', @event.store
+    end
+  end
+end


### PR DESCRIPTION
Close #136

This gem will now subscribe to the event `cache_delete_matched.active_support`.