### PR TITLE
Support cache_cleanup.active_support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 | [`cache_delete.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-delete-active-support)                     | ✅        |
 | [`cache_delete_multi.active_support`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-delete-multi-active-support)     | ✅        |
 | [`cache_delete_matched.active_support`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-delete-matched-active-support) | ✅        |
-| [`cache_cleanup.active_support`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-cleanup-active-support)               |           |
+| [`cache_cleanup.active_support`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-cleanup-active-support)               | ✅        |
 | [`cache_prune.active_support`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-prune-active-support)                   |           |
 | [`cache_exist?.active_support`](https://guides.rubyonrails.org/active_support_instrumentation.html#cache-exist-questionmark-active-support)         | ✅        |
 

--- a/lib/rails_band/active_support/event/cache_cleanup.rb
+++ b/lib/rails_band/active_support/event/cache_cleanup.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActiveSupport
+    module Event
+      # A wrapper for the event that is passed to `cache_cleanup.active_support`.
+      class CacheCleanup < BaseEvent
+        def store
+          @store ||= @event.payload.fetch(:store)
+        end
+
+        def size
+          @size ||= @event.payload.fetch(:size)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/active_support/log_subscriber.rb
+++ b/lib/rails_band/active_support/log_subscriber.rb
@@ -11,6 +11,7 @@ require 'rails_band/active_support/event/cache_decrement'
 require 'rails_band/active_support/event/cache_delete'
 require 'rails_band/active_support/event/cache_delete_multi'
 require 'rails_band/active_support/event/cache_delete_matched'
+require 'rails_band/active_support/event/cache_cleanup'
 require 'rails_band/active_support/event/cache_exist'
 
 module RailsBand
@@ -61,6 +62,10 @@ module RailsBand
 
       def cache_delete_matched(event)
         consumer_of(__method__)&.call(Event::CacheDeleteMatched.new(event))
+      end
+
+      def cache_cleanup(event)
+        consumer_of(__method__)&.call(Event::CacheCleanup.new(event))
       end
 
       def cache_exist?(event)

--- a/test/dummy/app/controllers/users_controller.rb
+++ b/test/dummy/app/controllers/users_controller.rb
@@ -94,8 +94,7 @@ class UsersController < ApplicationController
   end
 
   def cache4
-    # HACK: cache_increment and cache_decrement events are emitted when using MemCacheStore or RedisCacheStore.
-    #       This code simulates the events.
+    # HACK: This code simulates the events that are specific to any cache store.
     ActiveSupport::Notifications.instrument('cache_increment.active_support',
                                             { key: 'INC1', store: 'RedisCacheStore', amount: 1 }) do
       # noop
@@ -106,6 +105,10 @@ class UsersController < ApplicationController
     end
     ActiveSupport::Notifications.instrument('cache_delete_matched.active_support',
                                             { key: 'MyDeleteMatched', store: 'Store!' }) do
+      # noop
+    end
+    ActiveSupport::Notifications.instrument('cache_cleanup.active_support',
+                                            { store: 'Store!', size: 2 }) do
       # noop
     end
     redirect_to users_path

--- a/test/rails_band/active_support/event/cache_cleanup_test.rb
+++ b/test/rails_band/active_support/event/cache_cleanup_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CacheCleanupTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = nil
+    RailsBand::ActiveSupport::LogSubscriber.consumers = {
+      'cache_cleanup.active_support': ->(event) { @event = event }
+    }
+  end
+
+  test 'returns name' do
+    get '/users/123/cache4'
+
+    assert_equal 'cache_cleanup.active_support', @event.name
+  end
+
+  test 'returns time' do
+    get '/users/123/cache4'
+
+    assert_instance_of Float, @event.time
+  end
+
+  test 'returns end' do
+    get '/users/123/cache4'
+
+    assert_instance_of Float, @event.end
+  end
+
+  test 'returns transaction_id' do
+    get '/users/123/cache4'
+
+    assert_instance_of String, @event.transaction_id
+  end
+
+  test 'returns cpu_time' do
+    get '/users/123/cache4'
+
+    assert_instance_of Float, @event.cpu_time
+  end
+
+  test 'returns idle_time' do
+    get '/users/123/cache4'
+
+    assert_instance_of Float, @event.idle_time
+  end
+
+  test 'returns allocations' do
+    get '/users/123/cache4'
+
+    assert_instance_of Integer, @event.allocations
+  end
+
+  test 'returns duration' do
+    get '/users/123/cache4'
+
+    assert_instance_of Float, @event.duration
+  end
+
+  test 'calls #to_h' do
+    get '/users/123/cache4'
+
+    %i[name time end transaction_id cpu_time idle_time allocations duration store size].each do |key|
+      assert_includes @event.to_h, key
+    end
+  end
+
+  test 'calls #slice' do
+    get '/users/123/cache4'
+
+    assert_equal({ name: 'cache_cleanup.active_support' }, @event.slice(:name))
+  end
+
+  test 'returns an instance of CacheCleanup' do
+    get '/users/123/cache4'
+
+    assert_instance_of RailsBand::ActiveSupport::Event::CacheCleanup, @event
+  end
+
+  test 'returns size' do
+    get '/users/123/cache4'
+
+    assert_equal 2, @event.size
+  end
+
+  test 'returns store' do
+    get '/users/123/cache4'
+
+    assert_equal 'Store!', @event.store
+  end
+end


### PR DESCRIPTION
Close #137

This will support [cache_cleanup.active_support](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#cache-cleanup-active-support).