### PR TITLE
Support message_serializer_fallback.active_support

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 
 | Event name                                                                                                                                                        | Supported |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
-| [`message_serializer_fallback.active_support`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#message-serializer-fallback-active-support) |           |
+| [`message_serializer_fallback.active_support`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#message-serializer-fallback-active-support) | ✅        |
 
 ### Active Job
 

--- a/lib/rails_band/active_support/event/message_serializer_fallback.rb
+++ b/lib/rails_band/active_support/event/message_serializer_fallback.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActiveSupport
+    module Event
+      # A wrapper for the event that is passed to `message_serializer_fallback.active_support`.
+      class MessageSerializerFallback < BaseEvent
+        def serializer
+          @serializer ||= @event.payload.fetch(:serializer)
+        end
+
+        def fallback
+          @fallback ||= @event.payload.fetch(:fallback)
+        end
+
+        def serialized
+          @serialized ||= @event.payload.fetch(:serialized)
+        end
+
+        def deserialized
+          @deserialized ||= @event.payload.fetch(:deserialized)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/active_support/log_subscriber.rb
+++ b/lib/rails_band/active_support/log_subscriber.rb
@@ -14,6 +14,7 @@ require 'rails_band/active_support/event/cache_delete_matched'
 require 'rails_band/active_support/event/cache_cleanup'
 require 'rails_band/active_support/event/cache_prune'
 require 'rails_band/active_support/event/cache_exist'
+require 'rails_band/active_support/event/message_serializer_fallback'
 
 module RailsBand
   module ActiveSupport
@@ -75,6 +76,10 @@ module RailsBand
 
       def cache_exist?(event)
         consumer_of(__method__)&.call(Event::CacheExist.new(event))
+      end
+
+      def message_serializer_fallback(event)
+        consumer_of(__method__)&.call(Event::MessageSerializerFallback.new(event))
       end
 
       private

--- a/test/dummy/app/controllers/users_controller.rb
+++ b/test/dummy/app/controllers/users_controller.rb
@@ -126,6 +126,13 @@ class UsersController < ApplicationController
     redirect_to users_path
   end
 
+  def message_serializer_fallback
+    value = { 'foo' => 'bar' }
+    dumped = ActiveSupport::Messages::SerializerWithFallback[:json].dump(value)
+    ActiveSupport::Messages::SerializerWithFallback[:marshal].load(dumped)
+    redirect_to users_path
+  end
+
   private
 
   def halt!

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
     get :cache3
     get :cache4
     get :deprecation
+    get :message_serializer_fallback
   end
 
   resources :yay, only: %i[index show]

--- a/test/rails_band/active_support/event/message_serializer_fallback_test.rb
+++ b/test/rails_band/active_support/event/message_serializer_fallback_test.rb
@@ -63,7 +63,7 @@ if Gem::Version.new(Rails.version) >= Gem::Version.new('7.1')
       get '/users/123/message_serializer_fallback'
 
       %i[name time end transaction_id cpu_time idle_time allocations duration serializer fallback serialized
-       deserialized].each do |key|
+         deserialized].each do |key|
         assert_includes @event.to_h, key
       end
     end

--- a/test/rails_band/active_support/event/message_serializer_fallback_test.rb
+++ b/test/rails_band/active_support/event/message_serializer_fallback_test.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MessageSerializerFallbackTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = nil
+    RailsBand::ActiveSupport::LogSubscriber.consumers = {
+      'message_serializer_fallback.active_support': ->(event) { @event = event }
+    }
+  end
+
+  test 'returns name' do
+    get '/users/123/message_serializer_fallback'
+
+    assert_equal 'message_serializer_fallback.active_support', @event.name
+  end
+
+  test 'returns time' do
+    get '/users/123/message_serializer_fallback'
+
+    assert_instance_of Float, @event.time
+  end
+
+  test 'returns end' do
+    get '/users/123/message_serializer_fallback'
+
+    assert_instance_of Float, @event.end
+  end
+
+  test 'returns transaction_id' do
+    get '/users/123/message_serializer_fallback'
+
+    assert_instance_of String, @event.transaction_id
+  end
+
+  test 'returns cpu_time' do
+    get '/users/123/message_serializer_fallback'
+
+    assert_instance_of Float, @event.cpu_time
+  end
+
+  test 'returns idle_time' do
+    get '/users/123/message_serializer_fallback'
+
+    assert_instance_of Float, @event.idle_time
+  end
+
+  test 'returns allocations' do
+    get '/users/123/message_serializer_fallback'
+
+    assert_instance_of Integer, @event.allocations
+  end
+
+  test 'returns duration' do
+    get '/users/123/message_serializer_fallback'
+
+    assert_instance_of Float, @event.duration
+  end
+
+  test 'calls #to_h' do
+    get '/users/123/message_serializer_fallback'
+
+    %i[name time end transaction_id cpu_time idle_time allocations duration serializer fallback serialized
+       deserialized].each do |key|
+      assert_includes @event.to_h, key
+    end
+  end
+
+  test 'calls #slice' do
+    get '/users/123/message_serializer_fallback'
+
+    assert_equal({ name: 'message_serializer_fallback.active_support' }, @event.slice(:name))
+  end
+
+  test 'returns an instance of MessageSerializerFallback' do
+    get '/users/123/message_serializer_fallback'
+
+    assert_instance_of RailsBand::ActiveSupport::Event::MessageSerializerFallback, @event
+  end
+
+  test 'returns serializer' do
+    get '/users/123/message_serializer_fallback'
+
+    assert_equal :marshal, @event.serializer
+  end
+
+  test 'returns fallback' do
+    get '/users/123/message_serializer_fallback'
+
+    assert_equal :json, @event.fallback
+  end
+
+  test 'returns serialized' do
+    get '/users/123/message_serializer_fallback'
+
+    assert_equal '{"foo":"bar"}', @event.serialized
+  end
+
+  test 'returns deserialized' do
+    get '/users/123/message_serializer_fallback'
+
+    assert_equal({ 'foo' => 'bar' }, @event.deserialized)
+  end
+end

--- a/test/rails_band/active_support/event/message_serializer_fallback_test.rb
+++ b/test/rails_band/active_support/event/message_serializer_fallback_test.rb
@@ -2,104 +2,106 @@
 
 require 'test_helper'
 
-class MessageSerializerFallbackTest < ActionDispatch::IntegrationTest
-  setup do
-    @event = nil
-    RailsBand::ActiveSupport::LogSubscriber.consumers = {
-      'message_serializer_fallback.active_support': ->(event) { @event = event }
-    }
-  end
-
-  test 'returns name' do
-    get '/users/123/message_serializer_fallback'
-
-    assert_equal 'message_serializer_fallback.active_support', @event.name
-  end
-
-  test 'returns time' do
-    get '/users/123/message_serializer_fallback'
-
-    assert_instance_of Float, @event.time
-  end
-
-  test 'returns end' do
-    get '/users/123/message_serializer_fallback'
-
-    assert_instance_of Float, @event.end
-  end
-
-  test 'returns transaction_id' do
-    get '/users/123/message_serializer_fallback'
-
-    assert_instance_of String, @event.transaction_id
-  end
-
-  test 'returns cpu_time' do
-    get '/users/123/message_serializer_fallback'
-
-    assert_instance_of Float, @event.cpu_time
-  end
-
-  test 'returns idle_time' do
-    get '/users/123/message_serializer_fallback'
-
-    assert_instance_of Float, @event.idle_time
-  end
-
-  test 'returns allocations' do
-    get '/users/123/message_serializer_fallback'
-
-    assert_instance_of Integer, @event.allocations
-  end
-
-  test 'returns duration' do
-    get '/users/123/message_serializer_fallback'
-
-    assert_instance_of Float, @event.duration
-  end
-
-  test 'calls #to_h' do
-    get '/users/123/message_serializer_fallback'
-
-    %i[name time end transaction_id cpu_time idle_time allocations duration serializer fallback serialized
-       deserialized].each do |key|
-      assert_includes @event.to_h, key
+if Gem::Version.new(Rails.version) >= Gem::Version.new('7.1')
+  class MessageSerializerFallbackTest < ActionDispatch::IntegrationTest
+    setup do
+      @event = nil
+      RailsBand::ActiveSupport::LogSubscriber.consumers = {
+        'message_serializer_fallback.active_support': ->(event) { @event = event }
+      }
     end
-  end
 
-  test 'calls #slice' do
-    get '/users/123/message_serializer_fallback'
+    test 'returns name' do
+      get '/users/123/message_serializer_fallback'
 
-    assert_equal({ name: 'message_serializer_fallback.active_support' }, @event.slice(:name))
-  end
+      assert_equal 'message_serializer_fallback.active_support', @event.name
+    end
 
-  test 'returns an instance of MessageSerializerFallback' do
-    get '/users/123/message_serializer_fallback'
+    test 'returns time' do
+      get '/users/123/message_serializer_fallback'
 
-    assert_instance_of RailsBand::ActiveSupport::Event::MessageSerializerFallback, @event
-  end
+      assert_instance_of Float, @event.time
+    end
 
-  test 'returns serializer' do
-    get '/users/123/message_serializer_fallback'
+    test 'returns end' do
+      get '/users/123/message_serializer_fallback'
 
-    assert_equal :marshal, @event.serializer
-  end
+      assert_instance_of Float, @event.end
+    end
 
-  test 'returns fallback' do
-    get '/users/123/message_serializer_fallback'
+    test 'returns transaction_id' do
+      get '/users/123/message_serializer_fallback'
 
-    assert_equal :json, @event.fallback
-  end
+      assert_instance_of String, @event.transaction_id
+    end
 
-  test 'returns serialized' do
-    get '/users/123/message_serializer_fallback'
+    test 'returns cpu_time' do
+      get '/users/123/message_serializer_fallback'
 
-    assert_equal '{"foo":"bar"}', @event.serialized
-  end
+      assert_instance_of Float, @event.cpu_time
+    end
 
-  test 'returns deserialized' do
-    get '/users/123/message_serializer_fallback'
+    test 'returns idle_time' do
+      get '/users/123/message_serializer_fallback'
 
-    assert_equal({ 'foo' => 'bar' }, @event.deserialized)
+      assert_instance_of Float, @event.idle_time
+    end
+
+    test 'returns allocations' do
+      get '/users/123/message_serializer_fallback'
+
+      assert_instance_of Integer, @event.allocations
+    end
+
+    test 'returns duration' do
+      get '/users/123/message_serializer_fallback'
+
+      assert_instance_of Float, @event.duration
+    end
+
+    test 'calls #to_h' do
+      get '/users/123/message_serializer_fallback'
+
+      %i[name time end transaction_id cpu_time idle_time allocations duration serializer fallback serialized
+       deserialized].each do |key|
+        assert_includes @event.to_h, key
+      end
+    end
+
+    test 'calls #slice' do
+      get '/users/123/message_serializer_fallback'
+
+      assert_equal({ name: 'message_serializer_fallback.active_support' }, @event.slice(:name))
+    end
+
+    test 'returns an instance of MessageSerializerFallback' do
+      get '/users/123/message_serializer_fallback'
+
+      assert_instance_of RailsBand::ActiveSupport::Event::MessageSerializerFallback, @event
+    end
+
+    test 'returns serializer' do
+      get '/users/123/message_serializer_fallback'
+
+      assert_equal :marshal, @event.serializer
+    end
+
+    test 'returns fallback' do
+      get '/users/123/message_serializer_fallback'
+
+      assert_equal :json, @event.fallback
+    end
+
+    test 'returns serialized' do
+      get '/users/123/message_serializer_fallback'
+
+      assert_equal '{"foo":"bar"}', @event.serialized
+    end
+
+    test 'returns deserialized' do
+      get '/users/123/message_serializer_fallback'
+
+      assert_equal({ 'foo' => 'bar' }, @event.deserialized)
+    end
   end
 end


### PR DESCRIPTION
Close #139

[message_serializer_fallback.active_support](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#message-serializer-fallback-active-support) will be supported from this pull request.