### PR TITLE
Fix cache_write_multi_test to support normalized_hash in Rails edge

### DIFF
--- a/test/rails_band/active_support/event/cache_write_multi_test.rb
+++ b/test/rails_band/active_support/event/cache_write_multi_test.rb
@@ -81,7 +81,7 @@ class CacheWriteMultiTest < ActionDispatch::IntegrationTest
   test 'returns key' do
     get '/users/123/cache3'
 
-    assert_equal({ w1: 1, w2: 2 }, @event.key)
+    assert_equal({ w1: 1, w2: 2 }, @event.key.transform_keys(&:to_sym))
   end
 
   if Gem::Version.new(Rails.version) >= Gem::Version.new('6.1')


### PR DESCRIPTION
Thanks to https://github.com/rails/rails/pull/52723, the instrumentations for Active Support cache always provides `key` with String keys. So, I changed tests to always convert `key`'s keys symbols to always assert the same way between multiple Rails versions.