### PR TITLE
Updates "Supported Instrumentation API hooks"

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 
 ### Active Record
 
-| Event name                                                                                                                      | Supported |
-| ------------------------------------------------------------------------------------------------------------------------------- | --------- |
-| `strict_loading_violation.active_record` (Not yet documented. See the configuration of `action_on_strict_loading_violation`)    | ✅        |
-| [`sql.active_record`](https://guides.rubyonrails.org/active_support_instrumentation.html#sql-active-record)                     | ✅        |
-| [`instantiation.active_record`](https://guides.rubyonrails.org/active_support_instrumentation.html#instantiation-active-record) | ✅        |
+| Event name                                                                                                                                  | Supported |
+| ------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| `strict_loading_violation.active_record` (Not yet documented. See the configuration of `action_on_strict_loading_violation`)                | ✅        |
+| [`sql.active_record`](https://guides.rubyonrails.org/active_support_instrumentation.html#sql-active-record)                                 | ✅        |
+| [`instantiation.active_record`](https://guides.rubyonrails.org/active_support_instrumentation.html#instantiation-active-record)             | ✅        |
 | [`start_transaction.active_record`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#start-transaction-active-record) |           |
-| [`transaction.active_record`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#transaction-active-record) |           |
+| [`transaction.active_record`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#transaction-active-record)             |           |
 
 ### Action Mailer
 
@@ -177,8 +177,8 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 
 ### Railties
 
-| Event name                                                                                                                                | Supported |
-| ----------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| Event name                                                                                                                                    | Supported |
+| --------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
 | [`load_config_initializer.railties`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#load-config-initializer-railties) |           |
 
 ### Rails

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 | `strict_loading_violation.active_record` (Not yet documented. See the configuration of `action_on_strict_loading_violation`)    | ✅        |
 | [`sql.active_record`](https://guides.rubyonrails.org/active_support_instrumentation.html#sql-active-record)                     | ✅        |
 | [`instantiation.active_record`](https://guides.rubyonrails.org/active_support_instrumentation.html#instantiation-active-record) | ✅        |
+| [`start_transaction.active_record`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#start-transaction-active-record) |           |
 | [`transaction.active_record`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#transaction-active-record) |           |
 
 ### Action Mailer
@@ -178,7 +179,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 
 | Event name                                                                                                                                | Supported |
 | ----------------------------------------------------------------------------------------------------------------------------------------- | --------- |
-| [`load_config_initializer.railties`](https://guides.rubyonrails.org/active_support_instrumentation.html#load-config-initializer-railties) |           |
+| [`load_config_initializer.railties`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#load-config-initializer-railties) |           |
 
 ### Rails
 


### PR DESCRIPTION
Adds new `start_transaction.active_record` event to instrumentation table and updates link references from stable guides to edge guides for current Rails features