### PR TITLE
Support start_transaction.active_record

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ These are Rails Instrumentation API hooks supported by this gem so far.
 | `strict_loading_violation.active_record` (Not yet documented. See the configuration of `action_on_strict_loading_violation`)                | ✅        |
 | [`sql.active_record`](https://guides.rubyonrails.org/active_support_instrumentation.html#sql-active-record)                                 | ✅        |
 | [`instantiation.active_record`](https://guides.rubyonrails.org/active_support_instrumentation.html#instantiation-active-record)             | ✅        |
-| [`start_transaction.active_record`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#start-transaction-active-record) |           |
+| [`start_transaction.active_record`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#start-transaction-active-record) | ✅        |
 | [`transaction.active_record`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#transaction-active-record)             |           |
 
 ### Action Mailer

--- a/lib/rails_band/active_record/event/start_transaction.rb
+++ b/lib/rails_band/active_record/event/start_transaction.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module RailsBand
+  module ActiveRecord
+    module Event
+      # A wrapper for the event that is passed to `start_transaction.active_record`.
+      class StartTransaction < BaseEvent
+        def transaction
+          @transaction ||= @event.payload.fetch(:transaction)
+        end
+
+        def connection
+          @connection ||= @event.payload.fetch(:connection)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_band/active_record/log_subscriber.rb
+++ b/lib/rails_band/active_record/log_subscriber.rb
@@ -3,6 +3,7 @@
 require 'rails_band/active_record/event/sql'
 require 'rails_band/active_record/event/instantiation'
 require 'rails_band/active_record/event/strict_loading_violation'
+require 'rails_band/active_record/event/start_transaction'
 
 module RailsBand
   module ActiveRecord
@@ -20,6 +21,10 @@ module RailsBand
 
       def instantiation(event)
         consumer_of(__method__)&.call(Event::Instantiation.new(event))
+      end
+
+      def start_transaction(event)
+        consumer_of(__method__)&.call(Event::StartTransaction.new(event))
       end
 
       private

--- a/test/rails_band/active_record/event/start_transaction_test.rb
+++ b/test/rails_band/active_record/event/start_transaction_test.rb
@@ -2,92 +2,94 @@
 
 require 'test_helper'
 
-class StartTransactionTest < ActionDispatch::IntegrationTest
-  setup do
-    @event = nil
-    RailsBand::ActiveRecord::LogSubscriber.consumers = {
-      'start_transaction.active_record': ->(event) { @event = event }
-    }
-    @user = User.create!(name: 'foo', email: 'foo@example.com')
-  end
-
-  test 'returns name' do
-    User.transaction { @user.update!(name: 'bar') }
-
-    assert_equal 'start_transaction.active_record', @event.name
-  end
-
-  test 'returns time' do
-    User.transaction { @user.update!(name: 'bar') }
-
-    assert_instance_of Float, @event.time
-  end
-
-  test 'returns end' do
-    User.transaction { @user.update!(name: 'bar') }
-
-    assert_instance_of Float, @event.end
-  end
-
-  test 'returns transaction_id' do
-    User.transaction { @user.update!(name: 'bar') }
-
-    assert_instance_of String, @event.transaction_id
-  end
-
-  test 'returns cpu_time' do
-    User.transaction { @user.update!(name: 'bar') }
-
-    assert_instance_of Float, @event.cpu_time
-  end
-
-  test 'returns idle_time' do
-    User.transaction { @user.update!(name: 'bar') }
-
-    assert_instance_of Float, @event.idle_time
-  end
-
-  test 'returns allocations' do
-    User.transaction { @user.update!(name: 'bar') }
-
-    assert_instance_of Integer, @event.allocations
-  end
-
-  test 'returns duration' do
-    User.transaction { @user.update!(name: 'bar') }
-
-    assert_instance_of Float, @event.duration
-  end
-
-  test 'calls #to_h' do
-    User.transaction { @user.update!(name: 'bar') }
-
-    %i[name time end transaction_id cpu_time idle_time allocations duration transaction connection].each do |key|
-      assert_includes @event.to_h, key
+if Gem::Version.new(Rails.version) >= Gem::Version.new('7.2')
+  class StartTransactionTest < ActionDispatch::IntegrationTest
+    setup do
+      @event = nil
+      RailsBand::ActiveRecord::LogSubscriber.consumers = {
+        'start_transaction.active_record': ->(event) { @event = event }
+      }
+      @user = User.create!(name: 'foo', email: 'foo@example.com')
     end
-  end
 
-  test 'calls #slice' do
-    User.transaction { @user.update!(name: 'bar') }
+    test 'returns name' do
+      User.transaction { @user.update!(name: 'bar') }
 
-    assert_equal({ name: 'start_transaction.active_record' }, @event.slice(:name))
-  end
+      assert_equal 'start_transaction.active_record', @event.name
+    end
 
-  test 'returns an instance of StartTransaction' do
-    User.transaction { @user.update!(name: 'bar') }
+    test 'returns time' do
+      User.transaction { @user.update!(name: 'bar') }
 
-    assert_instance_of RailsBand::ActiveRecord::Event::StartTransaction, @event
-  end
+      assert_instance_of Float, @event.time
+    end
 
-  test 'returns transaction' do
-    User.transaction { @user.update!(name: 'bar') }
+    test 'returns end' do
+      User.transaction { @user.update!(name: 'bar') }
 
-    assert @event.transaction
-  end
+      assert_instance_of Float, @event.end
+    end
 
-  test 'returns connection' do
-    User.transaction { @user.update!(name: 'bar') }
+    test 'returns transaction_id' do
+      User.transaction { @user.update!(name: 'bar') }
 
-    assert @event.connection
+      assert_instance_of String, @event.transaction_id
+    end
+
+    test 'returns cpu_time' do
+      User.transaction { @user.update!(name: 'bar') }
+
+      assert_instance_of Float, @event.cpu_time
+    end
+
+    test 'returns idle_time' do
+      User.transaction { @user.update!(name: 'bar') }
+
+      assert_instance_of Float, @event.idle_time
+    end
+
+    test 'returns allocations' do
+      User.transaction { @user.update!(name: 'bar') }
+
+      assert_instance_of Integer, @event.allocations
+    end
+
+    test 'returns duration' do
+      User.transaction { @user.update!(name: 'bar') }
+
+      assert_instance_of Float, @event.duration
+    end
+
+    test 'calls #to_h' do
+      User.transaction { @user.update!(name: 'bar') }
+
+      %i[name time end transaction_id cpu_time idle_time allocations duration transaction connection].each do |key|
+        assert_includes @event.to_h, key
+      end
+    end
+
+    test 'calls #slice' do
+      User.transaction { @user.update!(name: 'bar') }
+
+      assert_equal({ name: 'start_transaction.active_record' }, @event.slice(:name))
+    end
+
+    test 'returns an instance of StartTransaction' do
+      User.transaction { @user.update!(name: 'bar') }
+
+      assert_instance_of RailsBand::ActiveRecord::Event::StartTransaction, @event
+    end
+
+    test 'returns transaction' do
+      User.transaction { @user.update!(name: 'bar') }
+
+      assert @event.transaction
+    end
+
+    test 'returns connection' do
+      User.transaction { @user.update!(name: 'bar') }
+
+      assert @event.connection
+    end
   end
 end

--- a/test/rails_band/active_record/event/start_transaction_test.rb
+++ b/test/rails_band/active_record/event/start_transaction_test.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class StartTransactionTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = nil
+    RailsBand::ActiveRecord::LogSubscriber.consumers = {
+      'start_transaction.active_record': ->(event) { @event = event }
+    }
+    @user = User.create!(name: 'foo', email: 'foo@example.com')
+  end
+
+  test 'returns name' do
+    User.transaction { @user.update!(name: 'bar') }
+
+    assert_equal 'start_transaction.active_record', @event.name
+  end
+
+  test 'returns time' do
+    User.transaction { @user.update!(name: 'bar') }
+
+    assert_instance_of Float, @event.time
+  end
+
+  test 'returns end' do
+    User.transaction { @user.update!(name: 'bar') }
+
+    assert_instance_of Float, @event.end
+  end
+
+  test 'returns transaction_id' do
+    User.transaction { @user.update!(name: 'bar') }
+
+    assert_instance_of String, @event.transaction_id
+  end
+
+  test 'returns cpu_time' do
+    User.transaction { @user.update!(name: 'bar') }
+
+    assert_instance_of Float, @event.cpu_time
+  end
+
+  test 'returns idle_time' do
+    User.transaction { @user.update!(name: 'bar') }
+
+    assert_instance_of Float, @event.idle_time
+  end
+
+  test 'returns allocations' do
+    User.transaction { @user.update!(name: 'bar') }
+
+    assert_instance_of Integer, @event.allocations
+  end
+
+  test 'returns duration' do
+    User.transaction { @user.update!(name: 'bar') }
+
+    assert_instance_of Float, @event.duration
+  end
+
+  test 'calls #to_h' do
+    User.transaction { @user.update!(name: 'bar') }
+
+    %i[name time end transaction_id cpu_time idle_time allocations duration transaction connection].each do |key|
+      assert_includes @event.to_h, key
+    end
+  end
+
+  test 'calls #slice' do
+    User.transaction { @user.update!(name: 'bar') }
+
+    assert_equal({ name: 'start_transaction.active_record' }, @event.slice(:name))
+  end
+
+  test 'returns an instance of StartTransaction' do
+    User.transaction { @user.update!(name: 'bar') }
+
+    assert_instance_of RailsBand::ActiveRecord::Event::StartTransaction, @event
+  end
+
+  test 'returns transaction' do
+    User.transaction { @user.update!(name: 'bar') }
+
+    assert @event.transaction
+  end
+
+  test 'returns connection' do
+    User.transaction { @user.update!(name: 'bar') }
+
+    assert @event.connection
+  end
+end


### PR DESCRIPTION
Support [start_transaction.active_record](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#start-transaction-active-record)