### PR TITLE
feat: Add Ruby 4.0 support to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0']
         rails: ['6.0', '6.1', '7.0', '7.1', '7.2', '8.0', '8.1', 'edge']
         exclude:
           - ruby: '2.6'
@@ -58,6 +58,16 @@ jobs:
             rails: '6.0'
           - ruby: '3.4'
             rails: '6.1'
+          - ruby: '4.0'
+            rails: '6.0'
+          - ruby: '4.0'
+            rails: '6.1'
+          - ruby: '4.0'
+            rails: '7.0'
+          - ruby: '4.0'
+            rails: '7.1'
+          - ruby: '4.0'
+            rails: '7.2'
     env:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.gemfile
 
@@ -66,7 +76,7 @@ jobs:
 
       - run: sudo apt-get update -y && sudo apt-get install -y --no-install-recommends libvips imagemagick
 
-      - uses: ruby/setup-ruby@ab177d40ee5483edb974554986f56b33477e21d0 # v1.265.0
+      - uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
@@ -78,7 +88,7 @@ jobs:
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
-      - uses: ruby/setup-ruby@ab177d40ee5483edb974554986f56b33477e21d0 # v1.265.0
+      - uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
         with:
           ruby-version: '3'
           bundler-cache: true


### PR DESCRIPTION
## Summary

Add Ruby 4.0 to the CI test matrix to officially support Ruby 4.0 in this project.

## Background

Ruby 4.0 has been released, and rails_band should declare official support by including it in the CI matrix. This follows the same pattern as previous Ruby/Rails version additions (e.g., #170, #173).

## Changes

- Added `'4.0'` to the `matrix.ruby` array in `.github/workflows/ci.yml`.
- Added exclude rules for Ruby 4.0 with Rails 6.0, 6.1, 7.0, 7.1, and 7.2, since Ruby 4.0 requires Rails 8.0 or later. Ruby 4.0 will be tested with Rails 8.0, 8.1, and edge.

## Testing

CI will run the new Ruby 4.0 matrix combinations automatically once this PR is merged.

## Related Issues

None