### PR TITLE
fix: Use client ID for app token workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0


### PR DESCRIPTION
## Summary

Update the GitHub App token creation step in the release workflow to use the recommended `client-id` input.

## Purpose

Remove the deprecation warning emitted by `actions/create-github-app-token@v3` for the legacy `app-id` input.

## Background

`actions/create-github-app-token@v3` now recommends the GitHub App Client ID via `client-id`. The repository variable `APP_CLIENT_ID` is already configured, so the release workflow can move away from the deprecated numeric App ID input.

## Changes

Replace `app-id: ${{ vars.APP_ID }}` with `client-id: ${{ vars.APP_CLIENT_ID }}` in `.github/workflows/release.yml`.

The existing private key secret and action version pin remain unchanged.

## Out of Scope

No action version bumps, private key changes, or release process changes are included.

## Related

- https://github.com/yykamei/block-merge-based-on-time/pull/3059 made the same migration in another repository to remove the `app-id` deprecation warning.

## Testing

- Verified no `app-id` / `APP_ID` references remain in `.github/workflows`.
- Verified `.github/workflows/release.yml` now references `client-id: ${{ vars.APP_CLIENT_ID }}`.

## Post-Release Verification

Confirm the next release workflow run no longer emits the `app-id` deprecation warning and that the app token step succeeds.

## Operational Notes

`vars.APP_CLIENT_ID` must remain set to the GitHub App Client ID. Labels, reviewers, and assignees are intentionally left unset.
